### PR TITLE
Add page for react-native-device-info component

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lowlight": "^1.17.0",
     "react": "16.13.1",
     "react-native": "0.63.2",
+    "react-native-device-info": "^7.3.1",
     "react-native-gesture-handler": "^1.6.1",
     "react-native-reanimated": "^1.10.0",
     "react-native-safe-area-context": "^3.1.0",

--- a/src/RNGalleryList.ts
+++ b/src/RNGalleryList.ts
@@ -5,6 +5,7 @@ import {TemplateExamplePage} from './examples/TemplateExamplePage';
 import {CheckBoxExamplePage} from './examples/CheckBoxExamplePage';
 import {DatePickerExamplePage} from './examples/DatePickerExamplePage';
 import {TimePickerExamplePage} from './examples/TimePickerExamplePage';
+import {DeviceInfoExamplePage} from './examples/DeviceInfoExamplePage';
 
 interface IRNGalleryExample {
   key: string;
@@ -31,6 +32,10 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
   {
     key: 'TimePicker',
     component: TimePickerExamplePage,
+  },
+  {
+    key: 'DeviceInfo',
+    component: DeviceInfoExamplePage,
   }
 ];
 

--- a/src/examples/DeviceInfoExamplePage.tsx
+++ b/src/examples/DeviceInfoExamplePage.tsx
@@ -1,0 +1,90 @@
+'use strict';
+import {Linking, StyleSheet, Text, View} from 'react-native';
+import React, { useEffect, useState } from 'react';
+import {Example} from '../components/Example';
+import {Page} from '../components/Page';
+import DeviceInfo, { getIpAddress, useDeviceName } from 'react-native-device-info';
+
+export const DeviceInfoExamplePage: React.FunctionComponent<{}> = () => {
+  const exampleSysInfo = `import DeviceInfo from 'react-native-device-info';
+
+function Example() {
+  return (
+    <>
+      <Text>System Name: {DeviceInfo.getSystemName()}</Text>
+      <Text>System Version: {DeviceInfo.getSystemVersion()}</Text>
+    </>
+  );
+}`;
+
+  const exampleDeviceInfo = `import { useDeviceName } from 'react-native-device-info';
+
+function Example() {
+  const deviceName = useDeviceName();
+  return <Text>Device Name: {JSON.stringify(deviceName, null, '  ')}</Text>;
+}`
+
+  const exampleNetworkInfo = `import DeviceInfo, { getIpAddress } from 'react-native-device-info';
+
+function Example() {
+  const [ipAddress, setIpAddress] = useState('');
+
+  useEffect(() => {
+    if (!ipAddress) {
+      getIpAddressAsync();
+    }
+  }, []);
+
+  const getIpAddressAsync = async () => {
+    const address = await getIpAddress();
+    setIpAddress(address);
+  };
+
+  return <Text>IP address: {ipAddress}</Text>;
+}`
+
+  const deviceName = useDeviceName();
+
+  const [ipAddress, setIpAddress] = useState('');
+
+  useEffect(() => {
+    if (!ipAddress) {
+      getIpAddressAsync();
+    }
+  }, []);
+
+  const getIpAddressAsync = async () => {
+    const address = await getIpAddress();
+    setIpAddress(address);
+  };
+
+  return (
+    <Page
+      title="Device Info"
+      description="Shows available device information via the react-native-device-info module.">
+
+      <View >
+        <Text>For more information about each platform's supported APIs, check out the{' '}
+          <Text style={{color: 'blue'}} onPress={() =>
+             Linking.openURL('https://github.com/react-native-device-info/react-native-device-info/blob/master/README.md#api')}>
+          documentation
+          </Text>
+        .
+        </Text>
+      </View>
+
+      <Example title="System Information" code={exampleSysInfo}>
+        <Text>System Name: {DeviceInfo.getSystemName()}</Text>
+        <Text>System Version: {DeviceInfo.getSystemVersion()}</Text>
+      </Example>
+
+      <Example title="Device Information" code={exampleDeviceInfo}>
+        <Text>Device Name: {JSON.stringify(deviceName, null, '  ')}</Text>
+      </Example>
+
+      <Example title="Network Information" code={exampleNetworkInfo}>
+        <Text>IP address: {ipAddress}</Text>
+      </Example>
+    </Page>
+  );
+};


### PR DESCRIPTION
Adds some examples for the `react-native-device-info` component.

![ApplicationFrameHost_M89F6ghpLD](https://user-images.githubusercontent.com/602268/101927769-bde1ef80-3bcc-11eb-8ab5-8a516c8f3a27.png)



