### PR TITLE
Add Theme Switch

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,10 @@
 import {AppRegistry} from 'react-native';
 import App from './src/App';
 import {name as appName} from './app.json';
+import {setGlobal} from 'reactn';
+
+setGlobal({
+  theme: 'system',
+});
 
 AppRegistry.registerComponent(appName, () => App);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-native-reanimated": "^1.10.0",
     "react-native-safe-area-context": "^3.1.0",
     "react-native-screens": "^2.9.0",
-    "react-native-windows": "^0.63.2"
+    "react-native-windows": "^0.63.2",
+    "reactn": "^2.2.7"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/src/SettingsPage.tsx
+++ b/src/SettingsPage.tsx
@@ -1,6 +1,7 @@
 'use strict';
 import {StyleSheet, Text, View} from 'react-native';
-import React, {useState} from 'react';
+import React from 'react';
+import {useGlobal} from 'reactn';
 import {Picker} from '@react-native-picker/picker';
 import {Page} from './components/Page';
 import {Hyperlink} from './components/Hyperlink';
@@ -31,7 +32,7 @@ const SettingContainer = (props: {
 
 export const SettingsPage: React.FunctionComponent<{}> = () => {
   //@ts-ignore
-  const [theme, setTheme] = useState('system');
+  const [theme, setTheme] = useGlobal('theme');
   const PickerValueChanged = (value: string | number, position: number) => {
     //@ts-ignore
     setTheme(value);

--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -1,6 +1,9 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import low from 'lowlight';
 import React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
+import {useGlobal} from 'reactn';
+import {AppTheme} from 'react-native-windows';
 
 const darkColors = {
   background: '#1E1E1E',
@@ -14,6 +17,20 @@ const darkColors = {
   jsxBrackets: '#80807a',
   types: '#4ec9b0',
   regexp: '#d16969',
+};
+
+const lightColors = {
+  background: '#E6E6E6',
+  text: '#000000',
+  comment: '#000000',
+  keyword: '#FF0000',
+  tag: '#000000',
+  number: '#000000',
+  string: '#0000FF',
+  jsxTags: '#A31515',
+  jsxBrackets: '#0000FF',
+  types: '#A31515',
+  regexp: '#000000',
 };
 
 const darkStyles = StyleSheet.create({
@@ -97,27 +114,147 @@ const darkStyles = StyleSheet.create({
   'hljs-attr': {color: darkColors.text}, // Attributes within JSX Tags
 });
 
+const lightStyles = StyleSheet.create({
+  'hljs-container': {
+    backgroundColor: lightColors.background,
+    flexGrow: 1,
+    padding: 5,
+  },
+  'hljs-global': {
+    color: lightColors.text,
+    fontFamily: 'Consolas',
+  },
+  'hljs-comment': {
+    color: lightColors.comment,
+    fontStyle: 'italic',
+  },
+  'hljs-quote': {
+    color: lightColors.comment,
+    fontStyle: 'italic',
+  },
+  'hljs-keyword': {
+    color: lightColors.keyword,
+  },
+  'hljs-selector-tag': {
+    color: lightColors.keyword,
+  },
+  'hljs-literal': {
+    color: lightColors.keyword,
+  },
+  'hljs-type': {
+    color: lightColors.keyword,
+  },
+  'hljs-addition': {
+    color: lightColors.keyword,
+  },
+  'hljs-number': {
+    color: lightColors.number,
+  },
+  'hljs-selector-attr': {
+    color: lightColors.number,
+  },
+  'hljs-symbol': {
+    color: lightColors.number,
+  },
+  'hljs-bullet': {
+    color: lightColors.number,
+  },
+  'hljs-subst': {
+    color: lightColors.number,
+  },
+  'hljs-meta': {
+    color: lightColors.number,
+  },
+  'hljs-link': {
+    color: lightColors.number,
+  },
+  'hljs-string': {
+    color: lightColors.string,
+  },
+  'hljs-doctag': {
+    color: lightColors.string,
+  },
+  'hljs-regexp': {
+    color: lightColors.regexp,
+  },
+  'hljs-emphasis': {
+    fontStyle: 'italic',
+  },
+  'hljs-function': {}, // Apply to whole function
+  'hljs-params': {}, // Apply to the parameters of a function
+  'hljs-built_in': {
+    color: lightColors.types,
+  },
+  'hljs-class': {},
+  'hljs-title': {
+    color: lightColors.jsxTags, //darkColors.classTypes,
+  },
+  xml: {}, // Apply to text within XML sections of JSX
+  'hljs-tag': {color: lightColors.jsxBrackets},
+  'hljs-name': {color: lightColors.jsxTags}, // Name within Component JSX Tags
+  'hljs-attr': {color: lightColors.text}, // Attributes within JSX Tags
+});
+
 function renderLowLightNode(node: lowlight.AST.Unist.Node) {
+  //@ts-ignore
+  const [theme, setTheme] = useGlobal('theme');
+  const themeStyles =
+    theme === 'system'
+      ? AppTheme.currentTheme === 'dark'
+        ? 1
+        : 0
+      : theme === 'dark'
+      ? 1
+      : 0;
   if (node.type === 'text') {
     return <Text>{(node as lowlight.AST.Text).value}</Text>;
   } else if (node.type === 'element') {
     const elementNode = node as lowlight.AST.Element;
-    if (
-      elementNode.properties.className &&
-      !darkStyles[elementNode.properties.className as keyof typeof darkStyles]
-    ) {
-      throw new Error(
-        `Missing code style for ${elementNode.properties.className}`,
+    if (themeStyles === 0) {
+      if (
+        elementNode.properties.className &&
+        !lightStyles[
+          elementNode.properties.className as keyof typeof lightStyles
+        ]
+      ) {
+        throw new Error(
+          `Missing code style for ${elementNode.properties.className}`,
+        );
+      }
+      const style = lightStyles[
+        elementNode.properties.className as keyof typeof lightStyles
+      ]
+        ? lightStyles[
+            elementNode.properties.className as keyof typeof lightStyles
+          ]
+        : {};
+      return (
+        <Text style={style}>
+          {elementNode.children.map(renderLowLightNode)}
+        </Text>
+      );
+    } else {
+      if (
+        elementNode.properties.className &&
+        !darkStyles[elementNode.properties.className as keyof typeof darkStyles]
+      ) {
+        throw new Error(
+          `Missing code style for ${elementNode.properties.className}`,
+        );
+      }
+      const style = darkStyles[
+        elementNode.properties.className as keyof typeof darkStyles
+      ]
+        ? darkStyles[
+            elementNode.properties.className as keyof typeof darkStyles
+          ]
+        : {};
+      return (
+        <Text style={style}>
+          {elementNode.children.map(renderLowLightNode)}
+        </Text>
       );
     }
-    const style = darkStyles[
-      elementNode.properties.className as keyof typeof darkStyles
-    ]
-      ? darkStyles[elementNode.properties.className as keyof typeof darkStyles]
-      : {};
-    return (
-      <Text style={style}>{elementNode.children.map(renderLowLightNode)}</Text>
-    );
   }
 
   return <Text>{JSON.stringify(node)}</Text>;
@@ -133,9 +270,32 @@ function renderLowLightTree(tree: lowlight.HastNode[]) {
 
 export function Code(props: {children: string}) {
   const tree = low.highlight('typescript', props.children).value;
+  //@ts-ignore
+  const [theme, setTheme] = useGlobal('theme');
+  const themeStyles =
+    theme === 'system'
+      ? AppTheme.currentTheme === 'dark'
+        ? 1
+        : 0
+      : theme === 'dark'
+      ? 1
+      : 0;
   return (
-    <View style={darkStyles['hljs-container']}>
-      <Text style={darkStyles['hljs-global']}>{renderLowLightTree(tree)}</Text>
+    <View
+      style={
+        themeStyles === 0
+          ? lightStyles['hljs-container']
+          : darkStyles['hljs-container']
+      }>
+      <Text
+        style={
+          themeStyles === 0
+            ? lightStyles['hljs-global']
+            : darkStyles['hljs-global']
+        }
+        selectable={true}>
+        {renderLowLightTree(tree)}
+      </Text>
     </View>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5952,6 +5952,13 @@ react@16.13.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
+reactn@^2.2.7:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/reactn/-/reactn-2.2.7.tgz#4d9a94ab0d8a540062666408e4bf1fae6892cecc"
+  integrity sha512-cqnt23kWN/ABqEZhW3OlpqI1DgTaaNDeHpSHtyd81qk0H1jd32zPTzJ69Hpzti2WakwNYveGFPIgI6i7E7nXOA==
+  dependencies:
+    use-force-update "^1.0.5"
+
 read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
@@ -7131,6 +7138,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+use-force-update@^1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/use-force-update/-/use-force-update-1.0.7.tgz#f5e672633f5a398b25c33b2287150918bcb3526b"
+  integrity sha512-k5dppYhO+I5X/cd7ildbrzeMZJkWwdAh5adaIk0qKN2euh7J0h2GBGBcB4QZ385eyHHnp7LIygvebdRx3XKdwA==
 
 use-subscription@^1.0.0, use-subscription@^1.4.0:
   version "1.4.1"


### PR DESCRIPTION
This PR is code that was originally in the Add Settings Page PR that has now been separated out for a clearer flow. 

Added Light Theme support for Code Snippets, tried to match coloring of syntax highlighting in XAML Controls Gallery. Added global state for theme. Using dropdown in Settings, users can select which theme they want shown for code snippets. 

Tried to add Theme toggle for entire app but DefaultTheme and DarkTheme from @react-navigation/native seem to only change background color and will NOT change text coloring or coloring of the app window. Only way to view dark or light theme for the app correctly is when the user's Windows system has selected for apps to display in dark or light theme. 

**_Example of Light Theme Code Snippet_**
![image](https://user-images.githubusercontent.com/34109996/102805216-be6a4b00-436f-11eb-9a09-a7eef98fce29.png)

**_Example of Dark Theme Code Snippet_**
![image](https://user-images.githubusercontent.com/34109996/102805310-e2c62780-436f-11eb-963a-37f741f5a06b.png)

