### PR TITLE
Add Build to PR, Fix Yarn Issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,23 +28,12 @@ jobs:
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1
 
-      - name: Check node modules cache
-        uses: actions/cache@v1
-        id: yarn-cache
-        with:
-          path: ./node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - name: Install node modules
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn --pure-lockfile
 
-      - name: yarn build
+      - name: Lint and Type Checks
         if: steps.yarn-cache.outputs.cache-hit == 'true'
         run: |
-          yarn build
           yarn tsc
           yarn lint
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,25 +1,46 @@
 name: PR
 
-on: [ pull_request_target ]
+on: [pull_request_target]
 
 jobs:
   # Set the job key. The key is displayed as the job name
   # when a job name is not provided
-  lint:
-    # Name the Job
-    name: Basic Checks
-    # Set the type of machine to run on
-    runs-on: ubuntu-latest
+  build:
+    name: Basic Checks and Build
+
+    runs-on: windows-latest
 
     steps:
-      # Checks out a copy of your repository on the ubuntu-latest machine
-      - name: Checkout code
-        uses: actions/checkout@v2        
-        with:          
-          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Checkout Code
+        uses: actions/checkout@v2
 
-      - run: yarn
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.9.1'
 
-      - run: yarn tsc
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1
+        with:
+          vs-version: '16.5'
 
-      - run: yarn lint
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1
+
+      - name: Install node modules
+        run: yarn --pure-lockfile
+
+      - name: Lint and Type Checks
+        if: steps.yarn-cache.outputs.cache-hit == 'true'
+        run: |
+          yarn tsc
+          yarn lint
+
+      - name: Run Windows x64 release
+        run: npx react-native run-windows --arch x64 --release --no-packager --no-deploy --logging --buildLogDirectory .\react-native-gallery\BuildLogs\x64
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: RN-Gallery-BuildLog
+          path: .\react-native-gallery\BuildLogs\x64


### PR DESCRIPTION
`yarn install` was being skipped with previous main.yml version for some commits. Change now always runs yarn install. 

Added native build to pr.yml so for PR checks to pass native build will run and must succeed. 