### PR TITLE
Fix permissions exception and some other improvements

### DIFF
--- a/src/examples/PermissionsExamplePage.tsx
+++ b/src/examples/PermissionsExamplePage.tsx
@@ -93,7 +93,8 @@ function Example() {
 
     return (
         <View key={status} style={{flex: 1, flexDirection: 'row', alignItems:'center', paddingBottom: 10}}>
-          <Button onPress={() => requestPermission(perm)} title="Request" disabled={status == 'unavailable' || status == 'blocked'} />
+          {status == 'granted' ? <Button onPress={() => {}} color='#008000' title="Granted" />
+                               : <Button onPress={() => requestPermission(perm)} title="Request" disabled={status == 'unavailable' || status == 'blocked'} />}
           <Text style={{fontWeight: 'bold', paddingLeft: 10}}>{item[0]}</Text>
           <Text style={{paddingLeft: 10}}>{getResultString(status)}</Text>
         </View>

--- a/src/examples/PermissionsExamplePage.tsx
+++ b/src/examples/PermissionsExamplePage.tsx
@@ -3,7 +3,7 @@ import {Button, FlatList, Text, View} from 'react-native';
 import React, {useEffect, useState} from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
-import {check, Permission, PERMISSIONS, PermissionStatus, request, RESULTS, WindowsPermission} from 'react-native-permissions';
+import {check, Permission, PERMISSIONS, PermissionStatus, request, RESULTS} from 'react-native-permissions';
 import {AndroidPermissionMap} from 'react-native-permissions/dist/typescript/permissions.android';
 import {IOSPermissionMap} from 'react-native-permissions/dist/typescript/permissions.ios';
 import {WindowsPermissionMap} from 'react-native-permissions/dist/typescript/permissions.windows';
@@ -27,7 +27,7 @@ type PermissionsMap = AndroidPermissionMap | IOSPermissionMap | WindowsPermissio
 
 export const PermissionsExamplePage: React.FunctionComponent<{}> = () => {
   const exampleJsx = `import React, { useEffect, useState } from 'react';
-import { Text } from 'react-native';
+import {Text} from 'react-native';
 import {check, Permission, PERMISSIONS, PermissionStatus, RESULTS} from 'react-native-permissions';
 
 function Example() {
@@ -35,18 +35,18 @@ function Example() {
 
   useEffect(() => {
     if (status == '') {
-      getPermissionAsync(PERMISSIONS.WINDOWS.USB);
+      getPermissionAsync(PERMISSIONS.WINDOWS.BLUETOOTH);
     }
   }, []);
 
-  const getPermissionAsync = async (perms: Permission) => {
+  const getPermissionAsync = async (perm: Permission) => {
     const results = new Map<Permission, PermissionStatus>();
-    const result = await check(k as Permission);
+    const result = await check(perm as Permission);
     setStatus(result);
   };
 
   return (
-    <Text>USB permission: {status}</Text>
+    <Text>Bluetooth permission: {status}</Text>
   );
 }
 `;
@@ -61,9 +61,15 @@ function Example() {
 
   const getPermissionsAsync = async (perms: PermissionsMap) => {
     const results = new Map<Permission, PermissionStatus>();
-    for(const k in perms) {
-      const result = await check(k as Permission);
-      results.set(k as Permission, result);
+    for(const [k, v] of Object.entries(perms)) {
+      // The following capabilities throw an exception in UWP are not available under
+      // the AppManifest editor in VS.
+      if (v == PERMISSIONS.WINDOWS.HUMANINTERFACEDEVICE ||
+          v == PERMISSIONS.WINDOWS.SERIALCOMMUNICATION ||
+          v == PERMISSIONS.WINDOWS.USB)
+        continue;
+      const result = await check(v as Permission);
+      results.set(v as Permission, result);
     }
     setPerms(results);
   };


### PR DESCRIPTION
Avoid using HID, Serial and USB permission checks since they can throw UWP exceptions.

So technically the exceptions issue was not really an hard crash, since the RNPermissions code
has a try/catch to deal with them, but under debug mode this causes issues since the default VS
behaviour is to stop the process when the exception is initially thrown.

I've also improved the UI and fixed another place where I was using the wrong permissions key.

Fixes https://github.com/microsoft/react-native-gallery/issues/62.

![ApplicationFrameHost_4pwuse1fY7](https://user-images.githubusercontent.com/602268/107680032-3df00880-6c95-11eb-8a11-76f8528ba35f.png)

