### PR TITLE
Update and enable Sketch Canvas page

### DIFF
--- a/src/RNGalleryList.ts
+++ b/src/RNGalleryList.ts
@@ -7,8 +7,7 @@ import {CheckBoxExamplePage} from './examples/CheckBoxExamplePage';
 import {ConfigExamplePage} from './examples/ConfigExamplePage';
 import {DatePickerExamplePage} from './examples/DatePickerExamplePage';
 import {TimePickerExamplePage} from './examples/TimePickerExamplePage';
-// Disabled waiting for RNW #7537
-//import {SketchExamplePage} from './examples/SketchExamplePage';
+import {SketchExamplePage} from './examples/SketchExamplePage';
 import {SliderExamplePage} from './examples/SliderExamplePage';
 // Disabled from #121
 //import {PermissionsExamplePage} from './examples/PermissionsExamplePage';
@@ -130,10 +129,10 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     key: 'Slider',
     component: SliderExamplePage,
   },
-  /*{
+  {
     key: 'Sketch',
     component: SketchExamplePage,
-  },*/
+  },
   {
     key: 'Switch',
     component: SwitchExamplePage,

--- a/src/examples/SketchExamplePage.tsx
+++ b/src/examples/SketchExamplePage.tsx
@@ -1,4 +1,4 @@
-/*'use strict';
+'use strict';
 import {StyleSheet, Text, View} from 'react-native';
 import React from 'react';
 import {Example} from '../components/Example';
@@ -99,4 +99,4 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     borderRadius: 5,
   },
-});*/
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1544,7 +1544,7 @@
 
 "@terrylinla/react-native-sketch-canvas@creambyemute/react-native-sketch-canvas":
   version "0.8.1"
-  resolved "https://codeload.github.com/creambyemute/react-native-sketch-canvas/tar.gz/41877111daeab2af4d493ec7a7239b8d48f0f229"
+  resolved "https://codeload.github.com/creambyemute/react-native-sketch-canvas/tar.gz/f381c467dfd153a1bf3255eba30a960ae89cea56"
 
 "@types/babel__core@^7.1.7":
   version "7.1.9"


### PR DESCRIPTION
Updates the `react-native-sketch-canvas` with the latest fixes to work on react-native-windows 0.64.4.
Re-enables the Sketch Canvas page.

It might be necessary to locally run `yarn cache clean` before getting the package.
I've tested it on Release and the Sketch Canvas page is working.