### PR TITLE
Rework the SensitiveInfo example page.

### DIFF
--- a/src/examples/SensitiveInfoExamplePage.tsx
+++ b/src/examples/SensitiveInfoExamplePage.tsx
@@ -68,20 +68,10 @@ export const SensitiveInfoExamplePage: React.FunctionComponent<{}> = () => {
         },
       ]}>
       <Example title="Sensitive Information" code={example}>
+        <Text style={{color: colors.text, marginBottom: 10}}>This example works just like a key-value store.</Text>
+        <Text style={{color: colors.text, marginBottom: 10}}>Data can be stored by inputting some text in the input box and pressing the "Set Item" button.</Text>
+        <Text style={{color: colors.text, marginBottom: 10}}>Retrieving the data can be done by pressing the "Get Item" button afterwards.</Text>
         <Text style={{color: colors.text, fontWeight: '500'}}>Key:key1 </Text>
-        <View style={{flex: 1, flexDirection: 'row', margin: 10}}>
-          <TextInput
-            style={{
-              width: 200,
-              height: 36,
-              borderColor: colors.border,
-              borderWidth: 1,
-            }}
-            value={value}
-            editable={false}
-          />
-          <Button color={colors.primary} onPress={getItem} title="Get Item" />
-        </View>
         <View style={{flex: 1, flexDirection: 'row', margin: 10}}>
           <TextInput
             style={{
@@ -94,6 +84,19 @@ export const SensitiveInfoExamplePage: React.FunctionComponent<{}> = () => {
             value={newValue}
           />
           <Button color={colors.primary} onPress={setItem} title="Set Item" />
+        </View>
+        <View style={{flex: 1, flexDirection: 'row', margin: 10}}>
+          <TextInput
+            style={{
+              width: 200,
+              height: 36,
+              borderColor: colors.border,
+              borderWidth: 1,
+            }}
+            value={value}
+            editable={false}
+          />
+          <Button color={colors.primary} onPress={getItem} title="Get Item" />
         </View>
       </Example>
     </Page>


### PR DESCRIPTION
This reworks the sensitive info page so the layout makes more sense (swapping the Get and Set item buttons), as well as adding some explanation text to make it clearer how it works.

Fixes https://github.com/microsoft/react-native-gallery/issues/113.

<img width="462" alt="ApplicationFrameHost_BSJLjQKWTM" src="https://user-images.githubusercontent.com/602268/116562830-6a620b00-a8fb-11eb-9121-eec2048ff027.png">
