### PR TITLE
Added note on build times

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ If you wish to build React Native Gallery on your computer locally, follow the f
 2. In the root directory of the repository on your device, run `yarn`.
 3. In the same directory run `npx react-native run-windows`.
 
+**Note: First builds will take considerably longer than subsequent builds due to the number of community modules consumed by the React Native Gallery**
+
 # Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a


### PR DESCRIPTION
Added a note to the README to notify users that the first build time will take longer than the others. This contributions is valuable because it will provide transparency to users that might not be familiar with the extended build times. 