### PR TITLE
Remove Certificate Password in CI

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,9 +1,9 @@
 schedules:
-  - cron: "0 0 * * *"
+  - cron: '0 0 * * *'
     displayName: Nightly Build
     branches:
       include:
-      - main
+        - main
     batch: true
 
 variables:
@@ -14,67 +14,67 @@ variables:
 pool: windevbuildagents
 
 steps:
-- checkout: self
-  clean: false
+  - checkout: self
+    clean: false
 
-- task: NuGetToolInstaller@0
-  inputs:
-    versionSpec: ">=5.8.0"
+  - task: NuGetToolInstaller@0
+    inputs:
+      versionSpec: '>=5.8.0'
 
-- task: NodeTool@0
-  displayName: Installing Node
-  inputs:
-    versionSpec: '14.x'
+  - task: NodeTool@0
+    displayName: Installing Node
+    inputs:
+      versionSpec: '14.x'
 
-- task: CmdLine@2
-  displayName: Installing Yarm
-  inputs:
-    script: npm install -g yarn
+  - task: CmdLine@2
+    displayName: Installing Yarm
+    inputs:
+      script: npm install -g yarn
 
-- task: NuGetCommand@2
-  displayName: NuGet restore
-  inputs:
-    command: restore
-    restoreSolution: windows/rngallery.sln
-    verbosityRestore: Detailed
+  - task: NuGetCommand@2
+    displayName: NuGet restore
+    inputs:
+      command: restore
+      restoreSolution: windows/rngallery.sln
+      verbosityRestore: Detailed
 
-- task: CmdLine@2
-  displayName: midgard-yarn (faster yarn install)
-  inputs:
-    script: npx midgard-yarn@1.23.14 --pure-lockfile
+  - task: CmdLine@2
+    displayName: midgard-yarn (faster yarn install)
+    inputs:
+      script: npx midgard-yarn@1.23.14 --pure-lockfile
 
-- task: CmdLine@2
-  displayName: Lint and Type Checks
-  inputs:
-    script: yarn tsc | yarn lint
+  - task: CmdLine@2
+    displayName: Lint and Type Checks
+    inputs:
+      script: yarn tsc | yarn lint
 
-- task: DownloadSecureFile@1
-  name: signingCert
-  displayName: 'Download CA certificate'
-  inputs:
-    secureFile: 'rngallery_Key.pfx'
+  - task: DownloadSecureFile@1
+    name: signingCert
+    displayName: 'Download CA certificate'
+    inputs:
+      secureFile: 'rngallery_Key.pfx'
 
-- task: CopyFiles@2
-  displayName: 'Copy Certificate to Windows Build Directory'
-  inputs:
-    SourceFolder: '$(signingCert.secureFilePath)'
-    Contents: 'rngallery_Key.pfx'
-    TargetFolder: '.\windows\rngallery\'
+  - task: CopyFiles@2
+    displayName: 'Copy Certificate to Windows Build Directory'
+    inputs:
+      SourceFolder: '$(signingCert.secureFilePath)'
+      Contents: 'rngallery_Key.pfx'
+      TargetFolder: '.\windows\rngallery\'
 
-- task: CmdLine@2
-  displayName: Build project (Release)
-  timeoutInMinutes: 60
-  inputs:
-    script: npx --no-install react-native run-windows --arch x64 --no-deploy --logging --buildLogDirectory $BuildLogDirectory\Release --msbuildprops PackageCertificateKeyFile=$(signingCert.secureFilePath),PackageCertificatePassword=$(rngallery_Password) --release
+  - task: CmdLine@2
+    displayName: Build project (Release)
+    timeoutInMinutes: 60
+    inputs:
+      script: npx --no-install react-native run-windows --arch x64 --no-deploy --logging --buildLogDirectory $BuildLogDirectory\Release --msbuildprops PackageCertificateKeyFile=$(signingCert.secureFilePath) --release
 
-- task: CmdLine@2
-  displayName: Remove the Pfx
-  inputs:
-    script: del /f .\windows\rngallery\rngallery_Key.pfx
+  - task: CmdLine@2
+    displayName: Remove the Pfx
+    inputs:
+      script: del /f .\windows\rngallery\rngallery_Key.pfx
 
-- task: PublishBuildArtifacts@1
-  displayName: Upload App
-  condition:  succeededOrFailed()
-  inputs:
-    pathtoPublish: .\windows\AppPackages\rngallery
-    artifactName: 'React Native Gallery - $(Agent.JobName)-$(System.JobAttempt)'
+  - task: PublishBuildArtifacts@1
+    displayName: Upload App
+    condition: succeededOrFailed()
+    inputs:
+      pathtoPublish: .\windows\AppPackages\rngallery
+      artifactName: 'React Native Gallery - $(Agent.JobName)-$(System.JobAttempt)'


### PR DESCRIPTION
**_What_**
Remove Stale Certificate Password MSBuild prop.

**_Why_**
No longer necessary with certificate from published React Native Gallery as it does not have a password. 

Note: Linter automatically applied other formatting changes. 