### PR TITLE
Update and fix react-native-print page for 0.64

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-native-device-info": "^7.3.1",
     "react-native-gesture-handler": "JaneaSystems/react-native-gesture-handler#windows",
     "react-native-permissions": "^3.0.0",
-    "react-native-print": "christopherdro/react-native-print",
+    "react-native-print": "0.8.0",
     "react-native-reanimated": "^1.10.0",
     "react-native-safe-area-context": "^3.1.0",
     "react-native-screens": "^2.9.0",

--- a/windows/rngallery/MainPage.xaml
+++ b/windows/rngallery/MainPage.xaml
@@ -8,9 +8,12 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-    <react:ReactRootView 
-        x:Name="ReactRootView"
-        ComponentName="rngallery"
-        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-        MinHeight="400"/>
+    <Grid>
+        <Canvas x:Name="RNPrintCanvas" Opacity="0" />
+        <react:ReactRootView
+            x:Name="ReactRootView"
+            ComponentName="rngallery"
+            Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+            MinHeight="400"/>
+    </Grid>
 </Page>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6157,9 +6157,10 @@ react-native-permissions@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.0.0.tgz#d9d107700741d41f8392f202f35a61f481fb0e68"
   integrity sha512-zBvf+o3NhgKmBk1I06GzZXaDfc9SUyO4M5TMcaCF1pwG1h4sI+XAv3gWSbryl6WnaZQc1zA+g7SocSoYcpJN5g==
 
-react-native-print@christopherdro/react-native-print:
-  version "0.7.0"
-  resolved "https://codeload.github.com/christopherdro/react-native-print/tar.gz/f51d0d1a60bf404bee08e48d68bd4c6ec65e8e65"
+react-native-print@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-print/-/react-native-print-0.8.0.tgz#9d200812ff2462c0d2421776dcab378e544a52fc"
+  integrity sha512-eldQMPw5YjhHLckIvG2EodLvADjjk42k//CMVqQJ7wJHpm6gk0znlZmSC/oz2M46J74dzLLVcq20xgt5lQTP6w==
 
 react-native-reanimated@^1.10.0:
   version "1.13.0"


### PR DESCRIPTION
Updates react-native-print to the latest release, which fixes the module for react-native-windows 0.64.
Re-adds the `RNPrintCanvas` element needed for printing using UWP's APIs.

Fix: https://github.com/microsoft/react-native-gallery/issues/109