### PR TITLE
Add specific commit to sketch-canvas dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@react-navigation/drawer": "^5.9.0",
     "@react-navigation/native": "^5.7.3",
     "@react-navigation/stack": "^5.9.0",
-    "@terrylinla/react-native-sketch-canvas": "creambyemute/react-native-sketch-canvas",
+    "@terrylinla/react-native-sketch-canvas": "git+https://github.com/creambyemute/react-native-sketch-canvas#1db88fa3cc6e8124b0baab3cb04bce0540900a33",
     "lowlight": "^1.17.0",
     "react": "16.13.1",
     "react-native": "^0.64.0-rc.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1542,9 +1542,9 @@
   dependencies:
     type-detect "4.0.8"
 
-"@terrylinla/react-native-sketch-canvas@creambyemute/react-native-sketch-canvas":
+"@terrylinla/react-native-sketch-canvas@git+https://github.com/creambyemute/react-native-sketch-canvas#1db88fa3cc6e8124b0baab3cb04bce0540900a33":
   version "0.8.1"
-  resolved "https://codeload.github.com/creambyemute/react-native-sketch-canvas/tar.gz/f381c467dfd153a1bf3255eba30a960ae89cea56"
+  resolved "git+https://github.com/creambyemute/react-native-sketch-canvas#1db88fa3cc6e8124b0baab3cb04bce0540900a33"
 
 "@types/babel__core@^7.1.7":
   version "7.1.9"


### PR DESCRIPTION
Adds a specific commit to the `react-native-sketch-canvas` dependency to try and avoid the need to run `yarn cache clean` when updating this dependency.

Fix: https://github.com/microsoft/react-native-gallery/issues/139