### PR TITLE
Expand View Examples to View Styling

### DIFF
--- a/src/examples/ViewExamplePage.tsx
+++ b/src/examples/ViewExamplePage.tsx
@@ -99,6 +99,30 @@ export const ViewExamplePage: React.FunctionComponent<{}> = () => {
     }} />
 </View>`;
 
+  const example7jsx = `<View
+style={{
+  height: 50,
+  width: 100,
+  borderColor: colors.primary,
+  backgroundColor: colors.border,
+  borderRightWidth: 10,
+  borderLeftWidth: 10,
+  borderWidth: 5,
+}}
+/>`;
+
+  const example8jsx = `<View
+style={{
+  height: 50,
+  width: 100,
+  borderTopLeftRadius: 4,
+  borderBottomRightRadius: 4,
+  borderColor: colors.text,
+  borderWidth: 5,
+  backgroundColor: colors.border,
+}}
+/>`;
+
   return (
     <Page
       title="View"
@@ -240,6 +264,32 @@ export const ViewExamplePage: React.FunctionComponent<{}> = () => {
             }}
           />
         </View>
+      </Example>
+      <Example title="A View with border styling." code={example7jsx}>
+        <View
+          style={{
+            height: 50,
+            width: 100,
+            borderColor: colors.primary,
+            backgroundColor: colors.border,
+            borderRightWidth: 10,
+            borderLeftWidth: 10,
+            borderWidth: 5,
+          }}
+        />
+      </Example>
+      <Example title="A View with varied border radius." code={example8jsx}>
+        <View
+          style={{
+            height: 50,
+            width: 100,
+            borderTopLeftRadius: 4,
+            borderBottomRightRadius: 4,
+            borderColor: colors.text,
+            borderWidth: 5,
+            backgroundColor: colors.border,
+          }}
+        />
       </Example>
     </Page>
   );

--- a/windows/rngallery/packages.config
+++ b/windows/rngallery/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />


### PR DESCRIPTION
Expanded View examples to include more View style props such as border*Width, border*Radius, and borderColor.