### PR TITLE
Cleanup theme to not use globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,5 @@
 import {AppRegistry} from 'react-native';
 import App from './src/App';
 import {name as appName} from './app.json';
-import {setGlobal} from 'reactn';
-
-setGlobal({
-  theme: 'system',
-});
 
 AppRegistry.registerComponent(appName, () => App);

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "react-native-tts": "ak1394/react-native-tts",
     "react-native-webview": "^11.6.2",
     "react-native-windows": "^0.64.10",
-    "react-native-xaml": "^0.0.18",
-    "reactn": "^2.2.7"
+    "react-native-xaml": "^0.0.18"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,11 +14,16 @@ import {
   createDrawerNavigator,
   DrawerContentScrollView,
   DrawerItemList,
-  DrawerItem,
 } from '@react-navigation/drawer';
 import RNGalleryList from './RNGalleryList';
 import LightTheme from './themes/LightTheme';
 import DarkTheme from './themes/DarkTheme';
+import {
+  ThemeMode,
+  RawThemeContext,
+  ThemeContext,
+  ThemeSetterContext,
+} from './themes/Theme';
 
 const styles = StyleSheet.create({
   container: {
@@ -109,10 +114,20 @@ function renderScreen(i: number) {
 }
 
 export default function App() {
+  const [rawtheme, setRawTheme] = React.useState<ThemeMode>('system');
+  const colorScheme = useColorScheme();
+  const theme = rawtheme === 'system' ? colorScheme! : rawtheme;
+
   return (
-    <NavigationContainer
-      theme={useColorScheme() === 'dark' ? DarkTheme : LightTheme}>
-      <MyDrawer />
-    </NavigationContainer>
+    <ThemeSetterContext.Provider value={setRawTheme}>
+      <RawThemeContext.Provider value={rawtheme}>
+        <ThemeContext.Provider value={theme}>
+          <NavigationContainer
+            theme={theme === 'dark' ? DarkTheme : LightTheme}>
+            <MyDrawer />
+          </NavigationContainer>
+        </ThemeContext.Provider>
+      </RawThemeContext.Provider>
+    </ThemeSetterContext.Provider>
   );
 }

--- a/src/SettingsPage.tsx
+++ b/src/SettingsPage.tsx
@@ -1,7 +1,7 @@
 'use strict';
 import {StyleSheet, Text, View, ScrollView} from 'react-native';
 import React from 'react';
-import {useGlobal} from 'reactn';
+import {ThemeMode, RawThemeContext, ThemeSetterContext} from './themes/Theme';
 import {Picker} from '@react-native-picker/picker';
 import {HyperlinkButton} from 'react-native-xaml';
 import {useTheme} from '@react-navigation/native';
@@ -55,12 +55,12 @@ const SettingContainer = (props: {
 };
 
 export const SettingsPage: React.FunctionComponent<{}> = () => {
-  //@ts-ignore
-  const [theme, setTheme] = useGlobal('theme');
+  const theme = React.useContext(RawThemeContext);
+  const setTheme = React.useContext(ThemeSetterContext);
   const {colors} = useTheme();
   const styles = createStyles(colors);
-  const PickerValueChanged = (value: string | number, position: number) => {
-    //@ts-ignore
+  const PickerValueChanged = (value: ThemeMode) => {
+    console.log('Setting theme to: ' + value);
     setTheme(value);
   };
   return (

--- a/src/themes/Theme.ts
+++ b/src/themes/Theme.ts
@@ -1,0 +1,20 @@
+import {createContext} from 'react';
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+
+// The resolved theme, light or dark
+export const ThemeContext = createContext<'light' | 'dark'>('light');
+if (__DEV__) {
+  ThemeContext.displayName = 'ThemeContext';
+}
+
+// This will be system if the theme should follow the system, or light/dark if the user is overriding the default theme
+export const RawThemeContext = createContext<ThemeMode>('system');
+if (__DEV__) {
+  ThemeContext.displayName = 'RawThemeContext';
+}
+
+export const ThemeSetterContext = createContext((_theme: ThemeMode) => {});
+if (__DEV__) {
+  ThemeSetterContext.displayName = 'ThemeSetterContext';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6315,13 +6315,6 @@ react@17.0.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-reactn@^2.2.7:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/reactn/-/reactn-2.2.7.tgz#4d9a94ab0d8a540062666408e4bf1fae6892cecc"
-  integrity sha512-cqnt23kWN/ABqEZhW3OlpqI1DgTaaNDeHpSHtyd81qk0H1jd32zPTzJ69Hpzti2WakwNYveGFPIgI6i7E7nXOA==
-  dependencies:
-    use-force-update "^1.0.5"
-
 read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
@@ -7494,11 +7487,6 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
-
-use-force-update@^1.0.5:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/use-force-update/-/use-force-update-1.0.7.tgz#f5e672633f5a398b25c33b2287150918bcb3526b"
-  integrity sha512-k5dppYhO+I5X/cd7ildbrzeMZJkWwdAh5adaIk0qKN2euh7J0h2GBGBcB4QZ385eyHHnp7LIygvebdRx3XKdwA==
 
 use-subscription@^1.0.0, use-subscription@^1.4.0:
   version "1.4.1"


### PR DESCRIPTION
Removes the dependency on reactn.
Moves theme management to normal react hooks/contexts.
Fixes logic in Code component to properly get the theme, and stop using the legacy AppTheme module.
Removes some suppressions of typescript errors.
