### PR TITLE
Upgrade Badges to include Core Component and Community Module Badge

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {StyleSheet, View, Text} from 'react-native';
+import {SymbolIcon} from 'react-native-xaml';
+
+const styles = StyleSheet.create({
+  badgeContainer: {
+    paddingLeft: 10,
+    paddingRight: 10,
+    height: 28,
+    borderRadius: 3,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    margin: 2,
+  },
+  badgeText: {
+    fontSize: 15,
+    fontWeight: '400',
+    paddingRight: 4,
+  },
+});
+
+export function Badge(props: {
+  badgeColor: string;
+  textColor: string;
+  badgeTitle: string;
+  icon: number;
+  description: string;
+}) {
+  return (
+    <View
+      style={[styles.badgeContainer, {backgroundColor: props.badgeColor}]}
+      tooltip={props.description}>
+      <Text style={[styles.badgeText, {color: props.textColor}]}>
+        {props.badgeTitle}
+      </Text>
+      <SymbolIcon symbol={props.icon} foreground={props.textColor} />
+    </View>
+  );
+}

--- a/src/components/CommunityModuleBadge.tsx
+++ b/src/components/CommunityModuleBadge.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import {useTheme} from '@react-navigation/native';
+import {Badge} from './Badge';
+
+export function CommunityModuleBadge() {
+  const {colors} = useTheme();
+  return (
+    <Badge
+      badgeColor={colors.text}
+      textColor={colors.border}
+      badgeTitle="Community Module"
+      icon={57637}
+      description="This component is not a part of React Native core. The package for this component must be explicitly added in order to have access to this component in a React Native project."
+    />
+  );
+}

--- a/src/components/CoreComponentBadge.tsx
+++ b/src/components/CoreComponentBadge.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import {useTheme} from '@react-navigation/native';
+import {Badge} from './Badge';
+
+export function CoreComponentBadge() {
+  const {colors} = useTheme();
+  return (
+    <Badge
+      badgeColor={colors.primary}
+      textColor="white"
+      badgeTitle="Core Component"
+      icon={57611}
+      description="This component is a part of React Native Windows core. No additional library must be added in order to have access to this component in a React Native Windows project."
+    />
+  );
+}

--- a/src/components/NativeControlBadge.tsx
+++ b/src/components/NativeControlBadge.tsx
@@ -1,42 +1,16 @@
 import React from 'react';
-import {StyleSheet, View, Text, Image} from 'react-native';
 import {useTheme} from '@react-navigation/native';
-
-const createStyles = (colors: any) =>
-  StyleSheet.create({
-    badgeContainer: {
-      height: 24,
-      width: 220,
-      borderRadius: 2,
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'center',
-      backgroundColor: colors.border,
-    },
-    badgeText: {
-      fontSize: 14,
-      fontWeight: '400',
-      color: colors.text,
-      paddingRight: 4,
-    },
-    badgeIcon: {
-      width: 14,
-      resizeMode: 'contain',
-    },
-  });
+import {Badge} from './Badge';
 
 export function NativeControlBadge() {
   const {colors} = useTheme();
-  const styles = createStyles(colors);
   return (
-    <View
-      style={styles.badgeContainer}
-      tooltip="This component wraps a native Windows XAML control: its visual appearance, animations, etc. will always match its native Windows counterpart.">
-      <Text style={styles.badgeText}>Wrapped Windows Control</Text>
-      <Image
-        style={styles.badgeIcon}
-        source={require('../assets/monitor_icon.png')}
-      />
-    </View>
+    <Badge
+      badgeColor={colors.border}
+      textColor={colors.text}
+      badgeTitle="Wrapped Windows Control"
+      icon={57828}
+      description="This component wraps a native Windows XAML control: its visual appearance, animations, etc. will always match its native Windows counterpart."
+    />
   );
 }

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {ScrollView, StyleSheet, Text, View} from 'react-native';
 import {NativeControlBadge} from './NativeControlBadge';
+import {CoreComponentBadge} from './CoreComponentBadge';
+import {CommunityModuleBadge} from './CommunityModuleBadge';
 import {LinkContainer} from './LinkContainer';
 import {useTheme} from '@react-navigation/native';
 
@@ -30,11 +32,21 @@ const styles = StyleSheet.create({
   },
 });
 
-const DisplayBadge = (
+const DisplayNativeControlBadge = (
   wrappedNativeControl: {control: string; url: string} | undefined,
 ) => {
   if (wrappedNativeControl) {
     return <NativeControlBadge />;
+  } else {
+    return;
+  }
+};
+
+const DisplayComponentTypeBadge = (componentType: string) => {
+  if (componentType === 'Core') {
+    return <CoreComponentBadge />;
+  } else if (componentType === 'Community') {
+    return <CommunityModuleBadge />;
   } else {
     return;
   }
@@ -71,6 +83,7 @@ export function Page(props: {
   title: string;
   description?: string;
   wrappedNativeControl?: {control: string; url: string};
+  componentType: string;
   pageCodeUrl: string;
   documentation: {label: string; url: string}[];
   children: React.ReactNode;
@@ -80,7 +93,10 @@ export function Page(props: {
     <View style={styles.container}>
       <View style={styles.titlePane}>
         <Text style={[styles.title, {color: colors.text}]}>{props.title}</Text>
-        {DisplayBadge(props.wrappedNativeControl)}
+        <View>
+          {DisplayNativeControlBadge(props.wrappedNativeControl)}
+          {DisplayComponentTypeBadge(props.componentType)}
+        </View>
       </View>
 
       {props.description && (

--- a/src/examples/ButtonExamplePage.tsx
+++ b/src/examples/ButtonExamplePage.tsx
@@ -25,6 +25,7 @@ export const ButtonExamplePage: React.FunctionComponent<{}> = () => {
     <Page
       title="Button"
       description="A basic button component with a minimal level of customization. If you are looking for a more customizable, pressable component, see Touchable and Pressable."
+      componentType="Core"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/ButtonExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/CheckBoxExamplePage.tsx
+++ b/src/examples/CheckBoxExamplePage.tsx
@@ -16,6 +16,7 @@ export const CheckBoxExamplePage: React.FunctionComponent<{}> = () => {
         url:
           'https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.checkbox?view=winrt-19041',
       }}
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/CheckBoxExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/ConfigExamplePage.tsx
+++ b/src/examples/ConfigExamplePage.tsx
@@ -19,6 +19,7 @@ export const ConfigExamplePage: React.FunctionComponent<{}> = () => {
     <Page
       title="Config Variables"
       description="Shows exposed config variables via the react-native-config module. Keep in mind this module doesn't obfuscate or encrypt secrets for packaging, so do not store sensitive keys in .env."
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/ConfigExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/DatePickerExamplePage.tsx
+++ b/src/examples/DatePickerExamplePage.tsx
@@ -26,6 +26,7 @@ export const DatePickerExamplePage: React.FunctionComponent<{}> = () => {
         url:
           'https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.calendardatepicker?view=winrt-19041',
       }}
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/DatePickerExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/DeviceInfoExamplePage.tsx
+++ b/src/examples/DeviceInfoExamplePage.tsx
@@ -39,6 +39,7 @@ export const DeviceInfoExamplePage: React.FunctionComponent<{}> = () => {
     <Page
       title="Device Info"
       description="The DeviceInfo module shows available device information."
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/DeviceInfoExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/FlatListExamplePage.tsx
+++ b/src/examples/FlatListExamplePage.tsx
@@ -78,6 +78,7 @@ export const FlatListExamplePage: React.FunctionComponent<{}> = () => {
     <Page
       title="FlatList"
       description="A component for rendering flat lists in React Native which supports horizontal mode, headers, footers, separators, scroll loading, and more. "
+      componentType="Core"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/FlatListExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/FlyoutExamplePage.tsx
+++ b/src/examples/FlyoutExamplePage.tsx
@@ -131,6 +131,7 @@ export const FlyoutExamplePage: React.FunctionComponent<{}> = () => {
         url:
           'https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Controls.Flyout?view=winrt-19041',
       }}
+      componentType="Core"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/FlyoutExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/GestureHandlerExamplePage.tsx
+++ b/src/examples/GestureHandlerExamplePage.tsx
@@ -224,6 +224,7 @@ export const GestureHandlerExamplePage: React.FunctionComponent<{}> = () => {
     <Page
       title="Gesture Handler"
       description="Declarative API exposing platform native touch and gesture system to React Native."
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/GestureHandlerExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/ImageExamplePage.tsx
+++ b/src/examples/ImageExamplePage.tsx
@@ -48,6 +48,7 @@ export const ImageExamplePage: React.FunctionComponent<{}> = () => {
         url:
           'https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.grid?view=winrt-19041',
       }}
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/ImageExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/PermissionsExamplePage.tsx
+++ b/src/examples/PermissionsExamplePage.tsx
@@ -140,6 +140,7 @@ export const PermissionsExamplePage: React.FunctionComponent<{}> = () => {
     <Page
       title="Permissions"
       description="Allows requesting and showing available system permissions via the react-native-permissions module."
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/PermissionsExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/PickerExamplePage.tsx
+++ b/src/examples/PickerExamplePage.tsx
@@ -32,6 +32,7 @@ export const PickerExamplePage: React.FunctionComponent<{}> = () => {
         url:
           'https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.combobox?view=winrt-19041',
       }}
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/PickerExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/PopupExamplePage.tsx
+++ b/src/examples/PopupExamplePage.tsx
@@ -127,6 +127,7 @@ export const PopupExamplePage: React.FunctionComponent<{}> = () => {
         url:
           'https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.primitives.popup?view=winrt-19041',
       }}
+      componentType="Core"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/PopupExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/PressableExamplePage.tsx
+++ b/src/examples/PressableExamplePage.tsx
@@ -75,6 +75,7 @@ export const PressableExamplePage: React.FunctionComponent<{}> = () => {
     <Page
       title="Pressable"
       description="A component that detects various touch interactions."
+      componentType="Core"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/PressableExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/PrintExamplePage.tsx
+++ b/src/examples/PrintExamplePage.tsx
@@ -30,6 +30,7 @@ export const PrintExamplePage: React.FunctionComponent<{}> = () => {
     <Page
       title="Print"
       description="Print documents via the react-native-print module."
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/PrintExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/ProgressViewExamplePage.tsx
+++ b/src/examples/ProgressViewExamplePage.tsx
@@ -20,6 +20,7 @@ export const ProgressViewExamplePage: React.FunctionComponent<{}> = () => {
     <Page
       title="ProgressView"
       description="ProgressView is a component for displaying progress bars in your app."
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/ProgressViewExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/ScrollViewExample.tsx
+++ b/src/examples/ScrollViewExample.tsx
@@ -88,6 +88,7 @@ export const ScrollViewExamplePage: React.FunctionComponent<{}> = () => {
         url:
           'https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.scrollviewer?view=winrt-19041',
       }}
+      componentType="Core"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/ScrollViewExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/SensitiveInfoExamplePage.tsx
+++ b/src/examples/SensitiveInfoExamplePage.tsx
@@ -60,6 +60,7 @@ export const SensitiveInfoExamplePage: React.FunctionComponent<{}> = () => {
     <Page
       title="Sensitive Info"
       description="The Sensitive Info module allows for the handling of sensitive information."
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/PermissionsExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/SketchExamplePage.tsx
+++ b/src/examples/SketchExamplePage.tsx
@@ -56,6 +56,7 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
     <Page
       title="Sketch Canvas"
       description="Shows an example of the react-native-sketch-canvas component for sketching."
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/SketchExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/SliderExamplePage.tsx
+++ b/src/examples/SliderExamplePage.tsx
@@ -41,6 +41,7 @@ export const SliderExamplePage: React.FunctionComponent<{}> = () => {
         url:
           'https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.slider?view=winrt-19041',
       }}
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/SliderExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/SwitchExamplePage.tsx
+++ b/src/examples/SwitchExamplePage.tsx
@@ -44,6 +44,7 @@ export const SwitchExamplePage: React.FunctionComponent<{}> = () => {
         url:
           'https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.toggleswitch?view=winrt-19041',
       }}
+      componentType="Core"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/SwitchExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/TTSExamplePage.tsx
+++ b/src/examples/TTSExamplePage.tsx
@@ -57,6 +57,7 @@ export const TTSExamplePage: React.FunctionComponent<{}> = () => {
     <Page
       title="Text-to-Speech"
       description="Provides text-to-speech services using the OS native text-to-speech APIs."
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/TTSExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/TemplateExamplePage.tsx
+++ b/src/examples/TemplateExamplePage.tsx
@@ -23,7 +23,8 @@ export const TemplateExamplePage: React.FunctionComponent<{}> = () => {
       wrappedNativeControl={{
         control: 'Template',
         url: 'https://github.com/microsoft/react-native-windows',
-      }}
+      }} // Remove if component is non-native.
+      componentType="Core" // Remove if component is not a core component
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/TemplateExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/TextExamplePage.tsx
+++ b/src/examples/TextExamplePage.tsx
@@ -61,6 +61,7 @@ Here is a line of capitalized text with Right-to-Left writing direction and back
         url:
           'https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.textblock?view=winrt-19041',
       }}
+      componentType="Core"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/TextExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/TextInputExamplePage.tsx
+++ b/src/examples/TextInputExamplePage.tsx
@@ -65,6 +65,7 @@ export const TextInputExamplePage: React.FunctionComponent<{}> = () => {
         url:
           'https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.textbox?view=winrt-19041',
       }}
+      componentType="Core"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/TextInputExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/TimePickerExamplePage.tsx
+++ b/src/examples/TimePickerExamplePage.tsx
@@ -28,6 +28,7 @@ export const TimePickerExamplePage: React.FunctionComponent<{}> = () => {
         url:
           'https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.timepicker?view=winrt-19041',
       }}
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/TemplateExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/TouchableHighlightExamplePage.tsx
+++ b/src/examples/TouchableHighlightExamplePage.tsx
@@ -60,6 +60,7 @@ export const TouchableHighlightExamplePage: React.FunctionComponent<{}> = () => 
     <Page
       title="Touchable Highlight"
       description="A customizable View responsive to touch. The opacity of the View is decreased when pressed, revealing an underlay color."
+      componentType="Core"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/TouchableHighlightExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/TouchableOpacityExamplePage.tsx
+++ b/src/examples/TouchableOpacityExamplePage.tsx
@@ -97,6 +97,7 @@ onPress={() => {}}>
     <Page
       title="Touchable Opacity"
       description="A customizable View responsive to touch. The opacity of the View is decreased when pressed, dimming it."
+      componentType="Core"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/TouchableOpacityExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/ViewExamplePage.tsx
+++ b/src/examples/ViewExamplePage.tsx
@@ -132,6 +132,7 @@ style={{
         url:
           'https://github.com/microsoft/react-native-windows/blob/master/vnext/Microsoft.ReactNative/Views/ViewPanel.',
       }}
+      componentType="Core"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/ViewExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/WebViewExamplePage.tsx
+++ b/src/examples/WebViewExamplePage.tsx
@@ -19,6 +19,7 @@ export const WebViewExamplePage: React.FunctionComponent<{}> = () => {
         control: 'WebView',
         url: 'https://github.com/react-native-webview/react-native-webview',
       }}
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/WebViewExamplePage.tsx"
       documentation={[
         {

--- a/src/examples/XamlExamplePage.tsx
+++ b/src/examples/XamlExamplePage.tsx
@@ -82,6 +82,7 @@ export const XamlExamplePage: React.FunctionComponent<{}> = () => {
     <Page
       title="Xaml"
       description="A React Native Windows view manager that allows direct use of the Windows XAML framework."
+      componentType="Community"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/XamlExamplePage.tsx"
       documentation={[
         {


### PR DESCRIPTION
**_Why_**
Expanded set of badges on component page so that more contextual information about the component will be displayed

**_What_**
- Added Core Component and Community Module badge to indicate what source a component is coming from. 
- Adjusted original Wrapped Native Control badge to use XAML SymbolIcon instead of an Image. 

Resolves #119 