### PR TITLE
add nightly builds with react-native-windows@canary

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -6,6 +6,15 @@ schedules:
         - main
     batch: true
 
+strategy:
+  matrix:
+    canary:
+      BUILD_CANARY: true
+      PUBLISH_APP: false
+    publish:
+      BUILD_CANARY: false
+      PUBLISH_APP: true
+
 variables:
   - group: rngallery_Variables
   - name: BuildLogDirectory
@@ -27,7 +36,13 @@ steps:
       versionSpec: '14.x'
 
   - task: CmdLine@2
-    displayName: Installing Yarm
+    displayName: Use react-native-windows@canary
+    condition: eq(variables['BUILD_CANARY'], 'true')
+    inputs:
+      script: node scripts/use-canary-version.js
+
+  - task: CmdLine@2
+    displayName: Installing Yarn
     inputs:
       script: npm install -g yarn
 
@@ -74,7 +89,7 @@ steps:
 
   - task: PublishBuildArtifacts@1
     displayName: Upload App
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), eq(variables['PUBLISH_APP'], 'true'))
     inputs:
       pathtoPublish: .\windows\AppPackages\rngallery
       artifactName: 'React Native Gallery - $(Agent.JobName)-$(System.JobAttempt)'

--- a/scripts/use-canary-version.js
+++ b/scripts/use-canary-version.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// @ts-check
+
+/**
+ * @typedef {{
+ *   version?: string;
+ *   dependencies?: Record<string, string>;
+ *   peerDependencies?: Record<string, string>;
+ *   devDependencies?: Record<string, string>;
+ * }} Manifest
+ */
+
+/**
+ * Fetches information about specified package.
+ * @param {string} pkg
+ * @return {Promise<Manifest>}
+ */
+function fetchPackageInfo(pkg) {
+  return new Promise((resolve) => {
+    const {spawn} = require('child_process');
+    const os = require('os');
+
+    /** @type {string[]} */
+    const result = [];
+
+    const npm = os.platform() === 'win32' ? 'npm.cmd' : 'npm';
+    const fetch = spawn(npm, ['view', '--json', pkg]);
+    fetch.stdout.on('data', (data) => result.push(data));
+    fetch.on('close', (code) => {
+      if (code !== 0 || result.length === 0) {
+        resolve({});
+      } else {
+        const list = JSON.parse(result.join(''));
+        const latest = Array.isArray(list) ? list[list.length - 1] : list;
+        resolve({
+          version: latest.version,
+          dependencies: latest.dependencies,
+          peerDependencies: latest.peerDependencies,
+          devDependencies: latest.devDependencies,
+        });
+      }
+    });
+  });
+}
+
+/**
+ * Fetches the latest react-native-windows@canary and modifies `package.json` to
+ * consume it.
+ */
+(async () => {
+  const canaryVersion = 'react-native-windows@canary';
+  const {version, peerDependencies} = await fetchPackageInfo(canaryVersion);
+  if (!version || !peerDependencies) {
+    throw new Error(`Failed to fetch info about ${canaryVersion}`);
+  }
+
+  const fs = require('fs/promises');
+
+  const data = await fs.readFile('package.json', {encoding: 'utf-8'});
+  const manifest = JSON.parse(data);
+
+  const canaryDependencies = {
+    react: peerDependencies['react'],
+    'react-native': peerDependencies['react-native'],
+    'react-native-windows': version,
+  };
+
+  manifest.dependencies = {
+    ...manifest.dependencies,
+    ...canaryDependencies,
+  };
+
+  fs.writeFile('package.json', JSON.stringify(manifest, undefined, 2) + '\n');
+
+  console.log(canaryDependencies);
+})();


### PR DESCRIPTION
## Description

### Why

We should verify that latest react-native-windows does not break us.

Resolves #165.

### What

Add a nightly builds with react-native-windows@canary.

## Screenshots

```
% node scripts/use-canary-version.js
{
  react: '17.0.2',
  'react-native': '0.0.0-20211111-2008-2ae06df58',
  'react-native-windows': '0.0.0-canary.428'
}
```