### PR TITLE
React Native Windows Hello added to the application

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "react-native-sensitive-info": "6.0.0-alpha.9",
     "react-native-track-player": "JaneaSystems/react-native-track-player#windows_cpp2",
     "react-native-tts": "ak1394/react-native-tts",
-    "react-native-xaml": "^0.0.45",
     "react-native-webview": "^11.15.0",
-    "react-native-windows": "0.67.0"
+    "react-native-windows": "0.67.0",
+    "react-native-xaml": "^0.0.45"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",
@@ -52,9 +52,10 @@
     "babel-jest": "^25.1.0",
     "eslint": "^6.5.1",
     "jest": "^25.1.0",
+    "metro-config": "^0.66.2",
+    "react-native-windows-hello": "^1.1.0",
     "react-test-renderer": "17.0.2",
-    "typescript": "^4.0.2",
-    "metro-config": "^0.66.2"
+    "typescript": "^4.0.2"
   },
   "jest": {
     "preset": "react-native",

--- a/src/RNGalleryList.ts
+++ b/src/RNGalleryList.ts
@@ -33,7 +33,7 @@ import {ProgressViewExamplePage} from './examples/ProgressViewExamplePage';
 //import {GestureHandlerExamplePage} from './examples/GestureHandlerExamplePage';
 import {XamlExamplePage} from './examples/XamlExamplePage';
 import {TrackPlayerExamplePage} from './examples/TrackPlayerExamplePage';
-import { WindowsHelloExamplePage } from './examples/WindowsHelloExamplePage';
+import {WindowsHelloExamplePage} from './examples/WindowsHelloExamplePage';
 // Disabled from #183
 //import {ExpanderExamplePage} from './examples/ExpanderExamplePage';
 

--- a/src/RNGalleryList.ts
+++ b/src/RNGalleryList.ts
@@ -33,6 +33,7 @@ import {ProgressViewExamplePage} from './examples/ProgressViewExamplePage';
 //import {GestureHandlerExamplePage} from './examples/GestureHandlerExamplePage';
 import {XamlExamplePage} from './examples/XamlExamplePage';
 import {TrackPlayerExamplePage} from './examples/TrackPlayerExamplePage';
+import { WindowsHelloExamplePage } from './examples/WindowsHelloExamplePage';
 // Disabled from #183
 //import {ExpanderExamplePage} from './examples/ExpanderExamplePage';
 
@@ -234,6 +235,12 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     component: WebViewExamplePage,
     icon: '\uE774',
     type: 'Media',
+  },
+  {
+    key: 'WindowsHello',
+    component: WindowsHelloExamplePage,
+    icon: '\uE890',
+    type: 'Status and Info',
   },
   {
     key: 'Xaml',

--- a/src/examples/WindowsHelloExamplePage.tsx
+++ b/src/examples/WindowsHelloExamplePage.tsx
@@ -2,13 +2,14 @@
 import React from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
-import { SignIn, verificationResult, availabilityStatus } from 'react-native-windows-hello';
-import {useTheme} from '@react-navigation/native';
-import { Alert, Button, View } from 'react-native';
+import {
+  SignIn,
+  verificationResult,
+  availabilityStatus,
+} from 'react-native-windows-hello';
+import {Alert, Button, View} from 'react-native';
 
 export const WindowsHelloExamplePage: React.FunctionComponent<{}> = () => {
-  const {colors} = useTheme();
-
   const example1jsx = `SignIn.getDeviceStatus()
   .then(result => {
     if (result === availabilityStatus.Available) {
@@ -59,55 +60,79 @@ export const WindowsHelloExamplePage: React.FunctionComponent<{}> = () => {
           url: 'https://github.com/callstack/react-native-windows-hello#readme',
         },
       ]}>
-      <Example title="Status of biometric device's availability." code={example1jsx}>
+      <Example
+        title="Status of biometric device's availability."
+        code={example1jsx}>
         <View>
-          <Button title='Check for biometric device!' onPress={() => {
-            SignIn.getDeviceStatus()
-              .then(result => {
-                if (result === availabilityStatus.Available) {
-                  Alert.alert("Biometric device available!", result.message);
-                } else {
-                  Alert.alert(`Biometric device status: ${result.value}`, result.message);
-                }
-              })
-              .catch(error => {
-                Alert.alert(error.message);
-              });
-          }}/>
+          <Button
+            title="Check for biometric device!"
+            onPress={() => {
+              SignIn.getDeviceStatus()
+                .then((result) => {
+                  if (result === availabilityStatus.Available) {
+                    Alert.alert('Biometric device available!', result.message);
+                  } else {
+                    Alert.alert(
+                      `Biometric device status: ${result.value}`,
+                      result.message,
+                    );
+                  }
+                })
+                .catch((error) => {
+                  Alert.alert(error.message);
+                });
+            }}
+          />
         </View>
       </Example>
       <Example title="Biometric scan with default message" code={example2jsx}>
         <View>
-        <Button title='Request user verification' onPress={() => {
-          SignIn.requestConsentVerification()
-            .then(result => {
-              if (result === verificationResult.Verified) {
-                Alert.alert("User verified SUCCESSFULLY!", result.message);
-              } else {
-                Alert.alert(`User verification failed: ${result.value}`, result.message);
-              }
-            })
-            .catch(error => {
-              Alert.alert(error);
-            });
-          }}/>
+          <Button
+            title="Request user verification"
+            onPress={() => {
+              SignIn.requestConsentVerification()
+                .then((result) => {
+                  if (result === verificationResult.Verified) {
+                    Alert.alert('User verified SUCCESSFULLY!', result.message);
+                  } else {
+                    Alert.alert(
+                      `User verification failed: ${result.value}`,
+                      result.message,
+                    );
+                  }
+                })
+                .catch((error) => {
+                  Alert.alert(error);
+                });
+            }}
+          />
         </View>
       </Example>
-      <Example title='Biometric scan with customized message: "Custom message displayed in verification prompt."' code={example3jsx}>
+      <Example
+        title='Biometric scan with customized message: "Custom message displayed in verification prompt."'
+        code={example3jsx}>
         <View>
-        <Button title='Request user verification' onPress={() => {
-          SignIn.requestConsentVerification("Custom message displayed in verification prompt.")
-            .then(result => {
-              if (result === verificationResult.Verified) {
-                Alert.alert("User verified SUCCESSFULLY!", result.message);
-              } else {
-                Alert.alert(`User verification failed: ${result.value}`, result.message);
-              }
-            })
-            .catch(error => {
-              Alert.alert(error);
-            });
-          }}/>
+          <Button
+            title="Request user verification"
+            onPress={() => {
+              SignIn.requestConsentVerification(
+                'Custom message displayed in verification prompt.',
+              )
+                .then((result) => {
+                  if (result === verificationResult.Verified) {
+                    Alert.alert('User verified SUCCESSFULLY!', result.message);
+                  } else {
+                    Alert.alert(
+                      `User verification failed: ${result.value}`,
+                      result.message,
+                    );
+                  }
+                })
+                .catch((error) => {
+                  Alert.alert(error);
+                });
+            }}
+          />
         </View>
       </Example>
     </Page>

--- a/src/examples/WindowsHelloExamplePage.tsx
+++ b/src/examples/WindowsHelloExamplePage.tsx
@@ -1,0 +1,115 @@
+'use strict';
+import React from 'react';
+import {Example} from '../components/Example';
+import {Page} from '../components/Page';
+import { SignIn, verificationResult, availabilityStatus } from 'react-native-windows-hello';
+import {useTheme} from '@react-navigation/native';
+import { Alert, Button, View } from 'react-native';
+
+export const WindowsHelloExamplePage: React.FunctionComponent<{}> = () => {
+  const {colors} = useTheme();
+
+  const example1jsx = `SignIn.getDeviceStatus()
+  .then(result => {
+    if (result === availabilityStatus.Available) {
+      Alert.alert("Biometric device available!", result.message);
+    } else {
+      Alert.alert(\`Biometric device status: \${result.value}\`, result.message);
+    }
+  })
+  .catch(error => {
+    Alert.alert(error.message);
+  });`;
+  const example2jsx = `SignIn.requestConsentVerification()
+  .then(result => {
+    if (result === verificationResult.Verified) {
+      Alert.alert("User verified SUCCESSFULLY!", result.message);
+    } else {
+      Alert.alert(\`User verification failed: \${result.value}\`, result.message);
+    }
+  })
+  .catch(error => {
+    Alert.alert(error);
+  });`;
+  const example3jsx = `SignIn.requestConsentVerification("Custom message displayed in verification prompt.")
+  .then(result => {
+    if (result === verificationResult.Verified) {
+      Alert.alert("User verified SUCCESSFULLY!", result.message);
+    } else {
+      Alert.alert(\`User verification failed: \${result.value}\`, result.message);
+    }
+  })
+  .catch(error => {
+    Alert.alert(error);
+  });`;
+  return (
+    <Page
+      title="Windows Hello"
+      description="Use a Windows Hello features when you want to authenticate users of your app and allow them to log in using their biometrics data defined for their Windows account."
+      wrappedNativeControl={{
+        control: 'Windows Hello',
+        url:
+          'https://support.microsoft.com/en-us/windows/learn-about-windows-hello-and-set-it-up-dae28983-8242-bb2a-d3d1-87c9d265a5f0',
+      }}
+      componentType="Community"
+      pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/WindowsHelloExamplePage.tsx"
+      documentation={[
+        {
+          label: 'React Native Windows Hello',
+          url: 'https://github.com/callstack/react-native-windows-hello#readme',
+        },
+      ]}>
+      <Example title="Status of biometric device's availability." code={example1jsx}>
+        <View>
+          <Button title='Check for biometric device!' onPress={() => {
+            SignIn.getDeviceStatus()
+              .then(result => {
+                if (result === availabilityStatus.Available) {
+                  Alert.alert("Biometric device available!", result.message);
+                } else {
+                  Alert.alert(`Biometric device status: ${result.value}`, result.message);
+                }
+              })
+              .catch(error => {
+                Alert.alert(error.message);
+              });
+          }}/>
+        </View>
+      </Example>
+      <Example title="Biometric scan with default message" code={example2jsx}>
+        <View>
+        <Button title='Request user verification' onPress={() => {
+          SignIn.requestConsentVerification()
+            .then(result => {
+              if (result === verificationResult.Verified) {
+                Alert.alert("User verified SUCCESSFULLY!", result.message);
+              } else {
+                Alert.alert(`User verification failed: ${result.value}`, result.message);
+              }
+            })
+            .catch(error => {
+              Alert.alert(error);
+            });
+          }}/>
+        </View>
+      </Example>
+      <Example title='Biometric scan with customized message: "Custom message displayed in verification prompt."' code={example3jsx}>
+        <View>
+        <Button title='Request user verification' onPress={() => {
+          SignIn.requestConsentVerification("Custom message displayed in verification prompt.")
+            .then(result => {
+              if (result === verificationResult.Verified) {
+                Alert.alert("User verified SUCCESSFULLY!", result.message);
+              } else {
+                Alert.alert(`User verification failed: ${result.value}`, result.message);
+              }
+            })
+            .catch(error => {
+              Alert.alert(error);
+            });
+          }}/>
+        </View>
+      </Example>
+    </Page>
+  );
+};

--- a/windows/rngallery.sln
+++ b/windows/rngallery.sln
@@ -67,6 +67,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactNativeXaml", "..\node_
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactNativeWebView", "..\node_modules\react-native-webview\windows\ReactNativeWebView\ReactNativeWebView.vcxproj", "{729D9AF8-CD9E-4427-9F6C-FB757E287729}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactNativeWindowsHello", "..\node_modules\react-native-windows-hello\windows\ReactNativeWindowsHello\ReactNativeWindowsHello.vcxproj", "{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{0986a4db-8e72-4bb7-ae32-7d9df1758a9d}*SharedItemsImports = 4
@@ -376,6 +378,18 @@ Global
 		{729D9AF8-CD9E-4427-9F6C-FB757E287729}.Release|x64.Build.0 = Release|x64
 		{729D9AF8-CD9E-4427-9F6C-FB757E287729}.Release|x86.ActiveCfg = Release|Win32
 		{729D9AF8-CD9E-4427-9F6C-FB757E287729}.Release|x86.Build.0 = Release|Win32
+		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Debug|ARM64.Build.0 = Debug|ARM64
+		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Debug|x64.ActiveCfg = Debug|x64
+		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Debug|x64.Build.0 = Debug|x64
+		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Debug|x86.ActiveCfg = Debug|Win32
+		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Debug|x86.Build.0 = Debug|Win32
+		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Release|ARM64.ActiveCfg = Release|ARM64
+		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Release|ARM64.Build.0 = Release|ARM64
+		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Release|x64.ActiveCfg = Release|x64
+		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Release|x64.Build.0 = Release|x64
+		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Release|x86.ActiveCfg = Release|Win32
+		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/windows/rngallery/AutolinkedNativeModules.g.cpp
+++ b/windows/rngallery/AutolinkedNativeModules.g.cpp
@@ -48,11 +48,14 @@
 // Includes from react-native-tts
 #include <winrt/RNTTS.h>
 
+// Includes from react-native-webview
+#include <winrt/ReactNativeWebView.h>
+
 // Includes from react-native-xaml
 #include <winrt/ReactNativeXaml.h>
 
-// Includes from react-native-webview
-#include <winrt/ReactNativeWebView.h>
+// Includes from react-native-windows-hello
+#include <winrt/ReactNativeWindowsHello.h>
 
 namespace winrt::Microsoft::ReactNative
 {
@@ -89,10 +92,12 @@ void RegisterAutolinkedNativeModulePackages(winrt::Windows::Foundation::Collecti
     packageProviders.Append(winrt::RNTrackPlayer::ReactPackageProvider());
     // IReactPackageProviders from react-native-tts
     packageProviders.Append(winrt::RNTTS::ReactPackageProvider());
-    // IReactPackageProviders from react-native-xaml
-    packageProviders.Append(winrt::ReactNativeXaml::ReactPackageProvider());
     // IReactPackageProviders from react-native-webview
     packageProviders.Append(winrt::ReactNativeWebView::ReactPackageProvider());
+    // IReactPackageProviders from react-native-xaml
+    packageProviders.Append(winrt::ReactNativeXaml::ReactPackageProvider());
+    // IReactPackageProviders from react-native-windows-hello
+    packageProviders.Append(winrt::ReactNativeWindowsHello::ReactPackageProvider());
 }
 
 }

--- a/windows/rngallery/AutolinkedNativeModules.g.targets
+++ b/windows/rngallery/AutolinkedNativeModules.g.targets
@@ -62,13 +62,17 @@
     <ProjectReference Include="$(ProjectDir)..\..\node_modules\react-native-tts\windows\RNTTS\RNTTS.vcxproj">
       <Project>{B250B404-D1A2-4171-851E-E80BA031DAF0}</Project>
     </ProjectReference>
+    <!-- Projects from react-native-webview -->
+    <ProjectReference Include="$(ProjectDir)..\..\node_modules\react-native-webview\windows\ReactNativeWebView\ReactNativeWebView.vcxproj">
+      <Project>{729d9af8-cd9e-4427-9f6c-fb757e287729}</Project>
+    </ProjectReference>
     <!-- Projects from react-native-xaml -->
     <ProjectReference Include="$(ProjectDir)..\..\node_modules\react-native-xaml\windows\ReactNativeXaml\ReactNativeXaml.vcxproj">
       <Project>{0ff7027a-222c-4ffb-8f17-91d18bbaf7a8}</Project>
     </ProjectReference>
-    <!-- Projects from react-native-webview -->
-    <ProjectReference Include="$(ProjectDir)..\..\node_modules\react-native-webview\windows\ReactNativeWebView\ReactNativeWebView.vcxproj">
-      <Project>{729d9af8-cd9e-4427-9f6c-fb757e287729}</Project>
+    <!-- Projects from react-native-windows-hello -->
+    <ProjectReference Include="$(ProjectDir)..\..\node_modules\react-native-windows-hello\windows\ReactNativeWindowsHello\ReactNativeWindowsHello.vcxproj">
+      <Project>{82bf2b2c-eda5-47ca-a9f5-56ba622a15ea}</Project>
     </ProjectReference>
   </ItemGroup>
 </Project>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5888,6 +5888,11 @@ react-native-webview@^11.15.0:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"
 
+react-native-windows-hello@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-windows-hello/-/react-native-windows-hello-1.1.0.tgz#91e7a8c7ca07554b380e887549df2e828b73eae8"
+  integrity sha512-XPPYLEPG3ffwida934ZHvGwqOE3AhshbvMPxl2/GKXS6QyX4XvcTMM4uVAFU6LyT2W7h2aVBkSqaxjFVBOACww==
+
 react-native-windows@0.67.0:
   version "0.67.0"
   resolved "https://registry.yarnpkg.com/react-native-windows/-/react-native-windows-0.67.0.tgz#d678c4260a99313862b4bdf189183b9b811b346e"


### PR DESCRIPTION
## Description

This pull request introduces the [callstack/react-native-windows-hello](https://github.com/callstack/react-native-windows-hello) in the gallery. The example contains all three options of library usage with basic examples (using `Alert` and `Button`): checking device availability and scanning user's biometrics with and without customized message.

### Why

Resolves #175 

### What

Standard `Page` has been implemented with basic code sample for each example. The new page was added to the `RNGalleryList` with the icon of View - the same as can be seen in the consent verification prompt when waiting for user's action.

## Screenshots
![WindowsHelloGallery](https://user-images.githubusercontent.com/70535775/155226728-c6f69223-9b5b-4543-956c-3609220d0891.gif)

