### PR TITLE
Adds onMouseEnter/onMouseLeave example to View page

### DIFF
--- a/src/examples/ViewExamplePage.tsx
+++ b/src/examples/ViewExamplePage.tsx
@@ -1,6 +1,6 @@
 'use strict';
 import {View} from 'react-native';
-import React from 'react';
+import React, {useState} from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
 import {useTheme} from '@react-navigation/native';
@@ -122,6 +122,19 @@ style={{
   backgroundColor: colors.border,
 }}
 />`;
+
+const example9jsx = `const [onHover, setOnHover] = useState(false);
+<View
+onMouseEnter={() => setOnHover(true)}
+onMouseLeave={() => setOnHover(false)}
+style={{
+   height: 50,
+   width: 100,
+   backgroundColor: onHover? colors.notification: colors.primary,
+}}
+/>`;
+
+  const [onHover, setOnHover] = useState(false);
 
   return (
     <Page
@@ -289,6 +302,17 @@ style={{
             borderColor: colors.text,
             borderWidth: 5,
             backgroundColor: colors.border,
+          }}
+        />
+      </Example>
+      <Example title="A View with onMouseEnter/onMouseLeave." code={example9jsx}>
+        <View
+          onMouseEnter={() => setOnHover(true)}
+          onMouseLeave={() => setOnHover(false)}
+          style={{
+            height: 50,
+            width: 100,
+            backgroundColor: onHover? colors.notification: colors.primary,
           }}
         />
       </Example>

--- a/src/examples/ViewExamplePage.tsx
+++ b/src/examples/ViewExamplePage.tsx
@@ -123,7 +123,7 @@ style={{
 }}
 />`;
 
-const example9jsx = `const [onHover, setOnHover] = useState(false);
+  const example9jsx = `const [onHover, setOnHover] = useState(false);
 <View
 onMouseEnter={() => setOnHover(true)}
 onMouseLeave={() => setOnHover(false)}
@@ -305,14 +305,16 @@ style={{
           }}
         />
       </Example>
-      <Example title="A View with onMouseEnter/onMouseLeave." code={example9jsx}>
+      <Example
+        title="A View with onMouseEnter/onMouseLeave."
+        code={example9jsx}>
         <View
           onMouseEnter={() => setOnHover(true)}
           onMouseLeave={() => setOnHover(false)}
           style={{
             height: 50,
             width: 100,
-            backgroundColor: onHover? colors.notification: colors.primary,
+            backgroundColor: onHover ? colors.notification : colors.primary,
           }}
         />
       </Example>


### PR DESCRIPTION
## Description
Adds example of onMouseEnter and onMouseLeave to View page in Gallery

### Why
Request for an example of these two properties, decided against making a whole example app for two properties and instead add to a core component in Gallery.

Resolves (https://github.com/microsoft/react-native-windows-samples/issues/541)

## Screenshots
https://user-images.githubusercontent.com/42554868/167467152-420f2b99-a38e-4e26-b83e-da74ddbf06f1.mp4


