### PR TITLE
Move Faulty Typescript Errors to Warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,5 +3,6 @@ module.exports = {
   extends: '@react-native-community',
   rules: {
     'react-native/no-inline-styles': 'off',
+    '@typescript-eslint/no-unused-vars': 'warn',
   },
 };


### PR DESCRIPTION
## Description

### Why

Typescript errors are firing as if variables are unused when they are being used within the source. Moving these errors to warnings until typescript-eslint is upgraded. 

Resolves #219 


