### PR TITLE
Add a tooltip to menu expand/collapse button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,6 +95,7 @@ function RNGalleryScreenWrapper({navigation}) {
         <TouchableHighlight
           accessibilityRole="button"
           accessibilityLabel="Navigation bar hambuger icon"
+          {...{tooltip: 'Expand Menu'}}
           accessibilityState={{expanded: isDrawerOpen}}
           style={styles.menu}
           onPress={() => navigation.openDrawer()}
@@ -143,7 +144,7 @@ function CustomDrawerContent(props) {
       <TouchableHighlight
         accessibilityRole="button"
         accessibilityLabel="Navigation bar expanded"
-        {...{tooltip: 'Expand/Collapse'}}
+        {...{tooltip: 'Collapse Menu'}}
         style={styles.menu}
         onPress={() => props.navigation.closeDrawer()}
         activeOpacity={0.5783}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -143,6 +143,7 @@ function CustomDrawerContent(props) {
       <TouchableHighlight
         accessibilityRole="button"
         accessibilityLabel="Navigation bar expanded"
+        {...{tooltip: 'Expand/Collapse'}}
         style={styles.menu}
         onPress={() => props.navigation.closeDrawer()}
         activeOpacity={0.5783}


### PR DESCRIPTION
## Description
"Cognitive Users will not be able to know the purpose of the button when there is no visible name or tooltip."

### Why

Resolves #223 

### What

Added a tooltip to the icon-only expand/collapse component. 

## Screenshots
![image](https://user-images.githubusercontent.com/41223743/179562553-888ca569-d7fa-4ae0-ae7a-e8581a8a8c97.png)
![image](https://user-images.githubusercontent.com/41223743/179562567-af7236f2-e298-41d1-99c7-1be38a520eb7.png)
