### PR TITLE
Fix homepage button name

### DIFF
--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -69,7 +69,11 @@ const HomeComponentTile = (props: {index: number; navigation}) => {
   return (
     <Pressable
       accessibilityRole="button"
-      accessibilityLabel={RNGalleryList[props.index].key + ' control'}
+      accessibilityLabel={
+        RNGalleryList[props.index].key === 'Button'
+          ? 'Button1 control'
+          : RNGalleryList[props.index].key + ' control'
+      }
       accessibilityHint={
         'click to view the ' + RNGalleryList[props.index].key + ' sample page'
       }


### PR DESCRIPTION
## Description
Changes from` button control` to `button1 control` name. Follows naming convention set by WinUI Gallery.

### Why
From new accessibility grading, missed button name in homepage
Resolves https://github.com/microsoft/react-native-gallery/issues/233

## Screenshots

![image](https://user-images.githubusercontent.com/42554868/180058585-0766ff5b-46a0-4f97-812d-ea8875988573.png)
