### PR TITLE
Add accessibilityValue to counter examples

### DIFF
--- a/src/examples/TouchableHighlightExamplePage.tsx
+++ b/src/examples/TouchableHighlightExamplePage.tsx
@@ -109,6 +109,7 @@ export const TouchableHighlightExamplePage: React.FunctionComponent<{}> = () => 
           accessibilityRole="button"
           accessibilityLabel={'example TouchableHighlight counter'}
           accessibilityHint={'click me to increase the example counter'}
+          accessibilityValue={{text: `${title}`}}
           style={{
             height: 40,
             backgroundColor: colors.text,

--- a/src/examples/TouchableOpacityExamplePage.tsx
+++ b/src/examples/TouchableOpacityExamplePage.tsx
@@ -167,6 +167,7 @@ onPress={() => {}}>
           accessibilityRole="button"
           accessibilityLabel={'example TouchableOpacity counter'}
           accessibilityHint={'click me to increase the example counter'}
+          accessibilityValue={{text: `${title}`}}
           style={{
             height: 40,
             width: 150,


### PR DESCRIPTION
## Description
Added accessibilityValue prop to the counter examples in TouchableHighlight and TouchableOpacity example pages. This will currently only announce the initial counter state and will not announce the changes unless focus moves away and back to the control. However, once https://github.com/microsoft/react-native-windows/pull/10318 is merged, narrator will announce the changes/provide success info when invoking these buttons. Once we upgrade gallery to 0.70, we can resolve the related ADO bug as well. 

Resolves: https://github.com/microsoft/react-native-gallery/issues/230


