### PR TITLE
Adds High Contrast Theming to Gallery

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,32 +219,30 @@ export default function App(props) {
   const theme = rawtheme === 'system' ? colorScheme! : rawtheme;
   appVersion = `${props.MajorVersion}.${props.MinorVersion}.${props.BuildVersion}.${props.RevisionVersion}`;
 
-  // const [isHighContrast, setHighContrast] = React.useState(
-  //   AppTheme.isHighContrast,
-  // );
+  const [isHighContrast, setHighContrast] = React.useState(
+    AppTheme.isHighContrast,
+  );
 
-  // React.useEffect(() => {
-  //   const subscription = AppTheme.addListener('highContrastChanged', () => {
-  //     setHighContrast(AppTheme.isHighContrast);
-  //     setHighContrastColorValues(AppTheme.currentHighContrastColors);
-  //   });
+  React.useEffect(() => {
+    const subscription = AppTheme.addListener('highContrastChanged', () => {
+      setHighContrast(AppTheme.isHighContrast);
+    });
 
-  //   return () => subscription.remove();
-  // });
-
-  // theme={
-  //   isHighContrast
-  //     ? HighContrastTheme
-  //     : theme === 'dark'
-  //     ? DarkTheme
-  //     : LightTheme
-  // }>
+    return () => subscription.remove();
+  });
 
   return (
     <ThemeSetterContext.Provider value={setRawTheme}>
       <RawThemeContext.Provider value={rawtheme}>
         <ThemeContext.Provider value={theme}>
-          <NavigationContainer theme={HighContrastTheme}>
+          <NavigationContainer
+            theme={
+              isHighContrast
+                ? HighContrastTheme
+                : theme === 'dark'
+                ? DarkTheme
+                : LightTheme
+            }>
             <MyDrawer />
           </NavigationContainer>
         </ThemeContext.Provider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {useState} from 'react';
 import {
   View,
   StyleSheet,
@@ -220,14 +219,14 @@ export default function App(props) {
   const theme = rawtheme === 'system' ? colorScheme! : rawtheme;
   appVersion = `${props.MajorVersion}.${props.MinorVersion}.${props.BuildVersion}.${props.RevisionVersion}`;
 
-  const [isHighContrast, setHighContrast] = useState(AppTheme.isHighContrast);
-  const [highContrastColorValues, sethighContrastColorValues] = useState(
-    AppTheme.currentHighContrastColors,
+  const [isHighContrast, setHighContrast] = React.useState(
+    AppTheme.isHighContrast,
   );
 
   React.useEffect(() => {
     const subscription = AppTheme.addListener('highContrastChanged', () => {
       setHighContrast(AppTheme.isHighContrast);
+      setHighContrastColorValues(AppTheme.currentHighContrastColors);
     });
 
     return () => subscription.remove();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,31 +219,32 @@ export default function App(props) {
   const theme = rawtheme === 'system' ? colorScheme! : rawtheme;
   appVersion = `${props.MajorVersion}.${props.MinorVersion}.${props.BuildVersion}.${props.RevisionVersion}`;
 
-  const [isHighContrast, setHighContrast] = React.useState(
-    AppTheme.isHighContrast,
-  );
+  // const [isHighContrast, setHighContrast] = React.useState(
+  //   AppTheme.isHighContrast,
+  // );
 
-  React.useEffect(() => {
-    const subscription = AppTheme.addListener('highContrastChanged', () => {
-      setHighContrast(AppTheme.isHighContrast);
-      setHighContrastColorValues(AppTheme.currentHighContrastColors);
-    });
+  // React.useEffect(() => {
+  //   const subscription = AppTheme.addListener('highContrastChanged', () => {
+  //     setHighContrast(AppTheme.isHighContrast);
+  //     setHighContrastColorValues(AppTheme.currentHighContrastColors);
+  //   });
 
-    return () => subscription.remove();
-  });
+  //   return () => subscription.remove();
+  // });
+
+  // theme={
+  //   isHighContrast
+  //     ? HighContrastTheme
+  //     : theme === 'dark'
+  //     ? DarkTheme
+  //     : LightTheme
+  // }>
 
   return (
     <ThemeSetterContext.Provider value={setRawTheme}>
       <RawThemeContext.Provider value={rawtheme}>
         <ThemeContext.Provider value={theme}>
-          <NavigationContainer
-            theme={
-              isHighContrast
-                ? HighContrastTheme
-                : theme === 'dark'
-                ? DarkTheme
-                : LightTheme
-            }>
+          <NavigationContainer theme={HighContrastTheme}>
             <MyDrawer />
           </NavigationContainer>
         </ThemeContext.Provider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {useState} from 'react';
 import {
   View,
   StyleSheet,
@@ -26,6 +27,8 @@ import {
   ThemeSetterContext,
 } from './themes/Theme';
 import {PlatformColor} from 'react-native';
+import {AppTheme} from 'react-native-windows';
+import HighContrastTheme from './themes/HighContrastTheme';
 
 let appVersion = '';
 
@@ -217,12 +220,31 @@ export default function App(props) {
   const theme = rawtheme === 'system' ? colorScheme! : rawtheme;
   appVersion = `${props.MajorVersion}.${props.MinorVersion}.${props.BuildVersion}.${props.RevisionVersion}`;
 
+  const [isHighContrast, setHighContrast] = useState(AppTheme.isHighContrast);
+  const [highContrastColorValues, sethighContrastColorValues] = useState(
+    AppTheme.currentHighContrastColors,
+  );
+
+  React.useEffect(() => {
+    const subscription = AppTheme.addListener('highContrastChanged', () => {
+      setHighContrast(AppTheme.isHighContrast);
+    });
+
+    return () => subscription.remove();
+  });
+
   return (
     <ThemeSetterContext.Provider value={setRawTheme}>
       <RawThemeContext.Provider value={rawtheme}>
         <ThemeContext.Provider value={theme}>
           <NavigationContainer
-            theme={theme === 'dark' ? DarkTheme : LightTheme}>
+            theme={
+              isHighContrast
+                ? HighContrastTheme
+                : theme === 'dark'
+                ? DarkTheme
+                : LightTheme
+            }>
             <MyDrawer />
           </NavigationContainer>
         </ThemeContext.Provider>

--- a/src/themes/HighContrastTheme.tsx
+++ b/src/themes/HighContrastTheme.tsx
@@ -4,11 +4,11 @@ import {AppTheme} from 'react-native-windows';
 const HighContrastTheme: Theme = {
   dark: false,
   colors: {
-    primary: AppTheme.currentHighContrastColors.ButtonFaceColor,
+    primary: AppTheme.currentHighContrastColors.HighlightColor,
     background: AppTheme.currentHighContrastColors.WindowColor,
     card: AppTheme.currentHighContrastColors.WindowColor,
     text: AppTheme.currentHighContrastColors.WindowTextColor,
-    border: AppTheme.currentHighContrastColors.HighlightColor,
+    border: AppTheme.currentHighContrastColors.ButtonTextColor,
     notification: AppTheme.currentHighContrastColors.HotlightColor,
   },
 };

--- a/src/themes/HighContrastTheme.tsx
+++ b/src/themes/HighContrastTheme.tsx
@@ -1,20 +1,15 @@
 import {Theme} from '@react-navigation/native';
 import {AppTheme} from 'react-native-windows';
 
-
-const [highContrastColorValues, setHighContrastColorValues] = React.useState(
-  AppTheme.currentHighContrastColors,
-);
-
 const HighContrastTheme: Theme = {
   dark: false,
   colors: {
-    primary: '#FFFFFF',
-    background: '#FFFFFF',
-    card: '#FFFFFF',
-    text: '#FFFFFF',
-    border: '#FFFFFF',
-    notification: '#FFFFFF',
+    primary: AppTheme.currentHighContrastColors.ButtonFaceColor,
+    background: AppTheme.currentHighContrastColors.WindowColor,
+    card: AppTheme.currentHighContrastColors.WindowColor,
+    text: AppTheme.currentHighContrastColors.WindowTextColor,
+    border: AppTheme.currentHighContrastColors.HighlightColor,
+    notification: AppTheme.currentHighContrastColors.HotlightColor,
   },
 };
 

--- a/src/themes/HighContrastTheme.tsx
+++ b/src/themes/HighContrastTheme.tsx
@@ -1,8 +1,13 @@
 import {Theme} from '@react-navigation/native';
 import {AppTheme} from 'react-native-windows';
 
+
+const [highContrastColorValues, setHighContrastColorValues] = React.useState(
+  AppTheme.currentHighContrastColors,
+);
+
 const HighContrastTheme: Theme = {
-  dark: false, //is this going to be a problem?
+  dark: false,
   colors: {
     primary: '#FFFFFF',
     background: '#FFFFFF',

--- a/src/themes/HighContrastTheme.tsx
+++ b/src/themes/HighContrastTheme.tsx
@@ -1,0 +1,16 @@
+import {Theme} from '@react-navigation/native';
+import {AppTheme} from 'react-native-windows';
+
+const HighContrastTheme: Theme = {
+  dark: false, //is this going to be a problem?
+  colors: {
+    primary: '#FFFFFF',
+    background: '#FFFFFF',
+    card: '#FFFFFF',
+    text: '#FFFFFF',
+    border: '#FFFFFF',
+    notification: '#FFFFFF',
+  },
+};
+
+export default HighContrastTheme;


### PR DESCRIPTION
## Description
Adds High Contrast Theming to Gallery

### Why

Improved accessibility and 'look' of gallery when high contrast system theme is set. 

Resolves: https://github.com/microsoft/react-native-gallery/issues/232

## Screenshots
### before: 
![image](https://user-images.githubusercontent.com/41223743/184710579-c00d957a-c8a7-40d8-8e78-2afa5146adc1.png)
![image](https://user-images.githubusercontent.com/41223743/184710594-f8673f3e-7d53-49b9-b019-057d96e84eaa.png)

### after:
![image](https://user-images.githubusercontent.com/41223743/184710621-cb44086c-b265-4eab-bd69-c09236c40870.png)
![image](https://user-images.githubusercontent.com/41223743/184710629-06cc19f1-b4ab-4a40-ac37-d0d90a895b51.png)
