### PR TITLE
Fix UIA Tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rngallery",
-  "version": "1.0.5.0",
+  "version": "1.0.13.0",
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,17 +6,13 @@ import {
   Text,
   useColorScheme,
   ScrollView,
-  Pressable,
 } from 'react-native';
-import {NavigationContainer, useNavigation} from '@react-navigation/native';
+import {NavigationContainer} from '@react-navigation/native';
 import {
   createDrawerNavigator,
   DrawerItem,
   getIsDrawerOpenFromState,
-  DrawerContentScrollView,
-  DrawerItemList,
 } from '@react-navigation/drawer';
-import {createStackNavigator} from '@react-navigation/stack';
 import RNGalleryList from './RNGalleryList';
 import LightTheme from './themes/LightTheme';
 import DarkTheme from './themes/DarkTheme';
@@ -30,21 +26,7 @@ import {PlatformColor} from 'react-native';
 import {AppTheme} from 'react-native-windows';
 import HighContrastTheme from './themes/HighContrastTheme';
 
-let appVersion = '';
-
 const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    width: '100%',
-    height: '100%',
-  },
-  navItem: {
-    flexGrow: 1,
-    flexShrink: 1,
-    height: '100%',
-    alignSelf: 'stretch',
-    paddingLeft: 10,
-  },
   menu: {
     margin: 5,
     height: 34,
@@ -62,15 +44,8 @@ const styles = StyleSheet.create({
     backgroundColor: PlatformColor('NavigationViewDefaultPaneBackground'),
     height: '100%',
   },
-  drawerItem: {
-    padding: 10,
-    height: 40,
-    flexDirection: 'row',
-    paddingLeft: 15,
-  },
   drawerText: {
     color: PlatformColor('TextControlForeground'),
-    paddingLeft: 10,
   },
   drawerTopDivider: {
     borderTopWidth: 0.5,
@@ -84,87 +59,33 @@ const styles = StyleSheet.create({
   },
 });
 
-// @ts-ignore
-function RNGalleryScreenWrapper(i: number) {
-  const Component = RNGalleryList[i].component;
-  //const navigation = useNavigation();
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-
+function RenderDrawerItem(props, i: number) {
+  const isDrawerOpen = getIsDrawerOpenFromState(props.navigation.getState());
   return (
-    <View style={styles.container}>
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel="Navigation bar"
-        accessibilityState={{expanded: isDrawerOpen}}
-        style={{
-          backgroundColor: PlatformColor('NavigationViewDefaultPaneBackground'),
-          width: isDrawerOpen ? 200 : 48,
-          height: '100%',
-        }}
-        onPress={() => {
-          isDrawerOpen ? setIsDrawerOpen(false) : setIsDrawerOpen(true);
-        }}>
-        <View>
-          <TouchableHighlight
-            accessibilityRole="button"
-            accessibilityLabel="Navigation bar hamburger icon"
-            {...{tooltip: 'Expand Menu'}}
-            accessibilityState={{expanded: isDrawerOpen}}
-            style={styles.menu}
-            onPress={() =>
-              isDrawerOpen ? setIsDrawerOpen(false) : setIsDrawerOpen(true)
-            }
-            activeOpacity={0.5783}
-            underlayColor="rgba(0, 0, 0, 0.0241);">
-            <Text style={styles.icon}>&#xE700;</Text>
-          </TouchableHighlight>
-          {RenderDrawer(isDrawerOpen)}
-        </View>
-      </Pressable>
-      <View style={styles.navItem}>
-        <Component appVersion={appVersion} />
-      </View>
-    </View>
-  );
-}
-
-function RenderDrawerItem(i: number) {
-  //const isDrawerOpen = getIsDrawerOpenFromState(props.navigation.getState());
-  //const navigation = useNavigation();
-  return (
-    <Pressable
-      //importantForAccessibility={isDrawerOpen ? 'auto' : 'no-hide-descendants'}
+    <DrawerItem
+      importantForAccessibility={isDrawerOpen ? 'auto' : 'no-hide-descendants'}
       key={RNGalleryList[i].key}
-      //onPress={() => navigation.navigate(RNGalleryList[i].key)}
+      label={() => {
+        return <Text style={styles.drawerText}>{RNGalleryList[i].key}</Text>;
+      }}
+      onPress={() => props.navigation.navigate(RNGalleryList[i].key)}
+      icon={() => {
+        return <Text style={styles.icon}>{RNGalleryList[i].icon}</Text>;
+      }}
       accessibilityLabel={RNGalleryList[i].key}
-      style={styles.drawerItem}>
-      <Text style={styles.icon}>{RNGalleryList[i].icon}</Text>
-      <Text style={styles.drawerText}>{RNGalleryList[i].key}</Text>
-    </Pressable>
+    />
   );
 }
 
-function RenderDrawer(isDrawerOpen: boolean) {
-  //const navigation = useNavigation();
-  if (!isDrawerOpen) {
-    return [];
-  }
+function RenderDrawer(props) {
   var items = [];
   // Begin iteration at index 2 because Home and
   // Settings drawer items have already been manually loaded.
   for (var i = 2; i < RNGalleryList.length; i++) {
-    items.push(RenderDrawerItem(i));
+    items.push(RenderDrawerItem(props, i));
   }
-  return (
-    <View>
-      {RenderDrawerItem(0)}
-      <ScrollView style={styles.drawer}>{items}</ScrollView>
-      {RenderDrawerItem(1)}
-    </View>
-  );
+  return items;
 }
-
-const Stack = createStackNavigator();
 
 function renderScreens() {
   const items = [];
@@ -177,7 +98,7 @@ function renderScreens() {
 
 function renderScreen(i: number) {
   return (
-    <Stack.Screen
+    <Drawer.Screen
       name={RNGalleryList[i].key}
       key={RNGalleryList[i].key}
       component={RNGalleryList[i].component}
@@ -185,16 +106,75 @@ function renderScreen(i: number) {
   );
 }
 
-function MyStack() {
+function CustomDrawerContent(props) {
+  const isDrawerOpen = getIsDrawerOpenFromState(props.navigation.getState());
+
+  return (
+    <View style={styles.drawer}>
+      <TouchableHighlight
+        importantForAccessibility={
+          isDrawerOpen ? 'auto' : 'no-hide-descendants'
+        }
+        accessibilityRole="button"
+        accessibilityLabel="Navigation bar expanded"
+        {...{tooltip: 'Collapse Menu'}}
+        style={styles.menu}
+        onPress={() => props.navigation.closeDrawer()}
+        activeOpacity={0.5783}
+        underlayColor="rgba(0, 0, 0, 0.0241);">
+        <Text style={styles.icon}>&#xE700;</Text>
+      </TouchableHighlight>
+      <DrawerItem
+        importantForAccessibility={
+          isDrawerOpen ? 'auto' : 'no-hide-descendants'
+        }
+        label={() => {
+          return <Text style={styles.drawerText}>Home</Text>;
+        }}
+        onPress={() => props.navigation.navigate('Home')}
+        icon={() => {
+          return <Text style={styles.icon}>&#xE80F;</Text>;
+        }}
+        style={styles.drawerBottomDivider}
+        accessibilityLabel={'home'}
+      />
+      <ScrollView {...props}>{RenderDrawer(props)}</ScrollView>
+      <DrawerItem
+        importantForAccessibility={
+          isDrawerOpen ? 'auto' : 'no-hide-descendants'
+        }
+        label={() => {
+          return <Text style={styles.drawerText}>Settings</Text>;
+        }}
+        onPress={() => props.navigation.navigate('Settings')}
+        icon={() => {
+          return <Text style={styles.icon}>&#xE713;</Text>;
+        }}
+        style={styles.drawerTopDivider}
+        accessibilityLabel={'settings'}
+      />
+    </View>
+  );
+}
+
+const Drawer = createDrawerNavigator();
+
+function MyDrawer() {
   let screens = renderScreens();
-  return <Stack.Navigator headerMode="none">{screens}</Stack.Navigator>;
+  return (
+    <Drawer.Navigator
+      drawerContent={(props) => (
+        <CustomDrawerContent {...props} drawerType="permanent" />
+      )}>
+      {screens}
+    </Drawer.Navigator>
+  );
 }
 
 export default function App(props) {
   const [rawtheme, setRawTheme] = React.useState<ThemeMode>('system');
   const colorScheme = useColorScheme();
   const theme = rawtheme === 'system' ? colorScheme! : rawtheme;
-  appVersion = `${props.MajorVersion}.${props.MinorVersion}.${props.BuildVersion}.${props.RevisionVersion}`;
 
   const [isHighContrast, setHighContrast] = React.useState(
     AppTheme.isHighContrast,
@@ -220,7 +200,7 @@ export default function App(props) {
                 ? DarkTheme
                 : LightTheme
             }>
-            <MyStack />
+            <MyDrawer />
           </NavigationContainer>
         </ThemeContext.Provider>
       </RawThemeContext.Provider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,6 +89,15 @@ const styles = StyleSheet.create({
 
 // @ts-ignore
 function RNGalleryScreenWrapper({navigation}) {
+  const state = useNavigationState((newState) => newState);
+  const entry = RNGalleryList.find(
+    (entry) => entry.key === state.routes[state.index].name,
+  );
+  console.log(state);
+  const Component = entry?.component;
+  //const Component = RNGalleryList[state.routes[state.index].name].component;
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
   return (
     <View style={styles.container}>
       <Pressable
@@ -192,14 +201,6 @@ export default function App(props) {
   const colorScheme = useColorScheme();
   const theme = rawtheme === 'system' ? colorScheme! : rawtheme;
   appVersion = `${props.MajorVersion}.${props.MinorVersion}.${props.BuildVersion}.${props.RevisionVersion}`;
-  const state = useNavigationState((newState) => newState);
-  const entry = RNGalleryList.find(
-    (entry) => entry.key === state.routes[state.index].name,
-  );
-  console.log(state);
-  const Component = entry?.component;
-  //const Component = RNGalleryList[state.routes[state.index].name].component;
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   const [isHighContrast, setHighContrast] = React.useState(
     AppTheme.isHighContrast,
@@ -225,41 +226,6 @@ export default function App(props) {
                 ? DarkTheme
                 : LightTheme
             }>
-            <View style={styles.container}>
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Navigation bar"
-                accessibilityState={{expanded: isDrawerOpen}}
-                style={{
-                  backgroundColor: PlatformColor(
-                    'NavigationViewDefaultPaneBackground',
-                  ),
-                  width: isDrawerOpen ? 200 : 48,
-                  height: '100%',
-                }}
-                onPress={() => {
-                  isDrawerOpen ? setIsDrawerOpen(false) : setIsDrawerOpen(true);
-                }}>
-                <View>
-                  <TouchableHighlight
-                    accessibilityRole="button"
-                    accessibilityLabel="Navigation bar hamburger icon"
-                    {...{tooltip: 'Expand Menu'}}
-                    accessibilityState={{expanded: isDrawerOpen}}
-                    style={styles.menu}
-                    onPress={() =>
-                      isDrawerOpen
-                        ? setIsDrawerOpen(false)
-                        : setIsDrawerOpen(true)
-                    }
-                    activeOpacity={0.5783}
-                    underlayColor="rgba(0, 0, 0, 0.0241);">
-                    <Text style={styles.icon}>&#xE700;</Text>
-                  </TouchableHighlight>
-                </View>
-              </Pressable>
-              <View style={styles.navItem} />
-            </View>
             <MyStack />
           </NavigationContainer>
         </ThemeContext.Provider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, {useState} from 'react';
 import {
   View,
   StyleSheet,
@@ -6,6 +6,7 @@ import {
   Text,
   useColorScheme,
   ScrollView,
+  Pressable,
 } from 'react-native';
 import {
   NavigationContainer,
@@ -15,7 +16,10 @@ import {
   createDrawerNavigator,
   DrawerItem,
   getIsDrawerOpenFromState,
+  DrawerContentScrollView,
+  DrawerItemList,
 } from '@react-navigation/drawer';
+import {createStackNavigator} from '@react-navigation/stack';
 import RNGalleryList from './RNGalleryList';
 import LightTheme from './themes/LightTheme';
 import DarkTheme from './themes/DarkTheme';
@@ -61,8 +65,15 @@ const styles = StyleSheet.create({
     backgroundColor: PlatformColor('NavigationViewDefaultPaneBackground'),
     height: '100%',
   },
+  drawerItem: {
+    padding: 10,
+    height: 40,
+    flexDirection: 'row',
+    paddingLeft: 15,
+  },
   drawerText: {
     color: PlatformColor('TextControlForeground'),
+    paddingLeft: 10,
   },
   drawerTopDivider: {
     borderTopWidth: 0.5,
@@ -78,34 +89,37 @@ const styles = StyleSheet.create({
 
 // @ts-ignore
 function RNGalleryScreenWrapper({navigation}) {
-  const state = useNavigationState((newState) => newState);
-  const Component = RNGalleryList[state.index].component;
-  const isDrawerOpen = getIsDrawerOpenFromState(navigation.getState());
-
   return (
     <View style={styles.container}>
-      <TouchableHighlight
+      <Pressable
         accessibilityRole="button"
         accessibilityLabel="Navigation bar"
         accessibilityState={{expanded: isDrawerOpen}}
         style={{
           backgroundColor: PlatformColor('NavigationViewDefaultPaneBackground'),
-          width: 48,
+          width: isDrawerOpen ? 200 : 48,
+          height: '100%',
         }}
-        underlayColor={PlatformColor('NavigationViewDefaultPaneBackground')}
-        onPress={() => navigation.openDrawer()}>
-        <TouchableHighlight
-          accessibilityRole="button"
-          accessibilityLabel="Navigation bar hambuger icon"
-          {...{tooltip: 'Expand Menu'}}
-          accessibilityState={{expanded: isDrawerOpen}}
-          style={styles.menu}
-          onPress={() => navigation.openDrawer()}
-          activeOpacity={0.5783}
-          underlayColor="rgba(0, 0, 0, 0.0241);">
-          <Text style={styles.icon}>&#xE700;</Text>
-        </TouchableHighlight>
-      </TouchableHighlight>
+        onPress={() => {
+          isDrawerOpen ? setIsDrawerOpen(false) : setIsDrawerOpen(true);
+        }}>
+        <View>
+          <TouchableHighlight
+            accessibilityRole="button"
+            accessibilityLabel="Navigation bar hamburger icon"
+            {...{tooltip: 'Expand Menu'}}
+            accessibilityState={{expanded: isDrawerOpen}}
+            style={styles.menu}
+            onPress={() =>
+              isDrawerOpen ? setIsDrawerOpen(false) : setIsDrawerOpen(true)
+            }
+            activeOpacity={0.5783}
+            underlayColor="rgba(0, 0, 0, 0.0241);">
+            <Text style={styles.icon}>&#xE700;</Text>
+          </TouchableHighlight>
+          {RenderDrawer({navigation}, isDrawerOpen)}
+        </View>
+      </Pressable>
       <View style={styles.navItem}>
         <Component appVersion={appVersion} navigation={navigation} />
       </View>
@@ -113,99 +127,41 @@ function RNGalleryScreenWrapper({navigation}) {
   );
 }
 
-function RenderDrawerItem(props, i: number) {
-  const isDrawerOpen = getIsDrawerOpenFromState(props.navigation.getState());
+function RenderDrawerItem({navigation}, i: number) {
+  //const isDrawerOpen = getIsDrawerOpenFromState(props.navigation.getState());
   return (
-    <DrawerItem
-      importantForAccessibility={isDrawerOpen ? 'auto' : 'no-hide-descendants'}
+    <Pressable
+      //importantForAccessibility={isDrawerOpen ? 'auto' : 'no-hide-descendants'}
       key={RNGalleryList[i].key}
-      label={() => {
-        return <Text style={styles.drawerText}>{RNGalleryList[i].key}</Text>;
-      }}
-      onPress={() => props.navigation.navigate(RNGalleryList[i].key)}
-      icon={() => {
-        return <Text style={styles.icon}>{RNGalleryList[i].icon}</Text>;
-      }}
+      onPress={() => navigation.navigate(RNGalleryList[i].key)}
       accessibilityLabel={RNGalleryList[i].key}
-    />
+      style={styles.drawerItem}>
+      <Text style={styles.icon}>{RNGalleryList[i].icon}</Text>
+      <Text style={styles.drawerText}>{RNGalleryList[i].key}</Text>
+    </Pressable>
   );
 }
 
-function RenderDrawer(props) {
+function RenderDrawer({navigation}, isDrawerOpen: boolean) {
+  if (!isDrawerOpen) {
+    return [];
+  }
   var items = [];
   // Begin iteration at index 2 because Home and
   // Settings drawer items have already been manually loaded.
   for (var i = 2; i < RNGalleryList.length; i++) {
-    items.push(RenderDrawerItem(props, i));
+    items.push(RenderDrawerItem({navigation}, i));
   }
-  return items;
-}
-
-// @ts-ignore
-function CustomDrawerContent(props) {
-  const isDrawerOpen = getIsDrawerOpenFromState(props.navigation.getState());
-
   return (
-    <View style={styles.drawer}>
-      <TouchableHighlight
-        importantForAccessibility={
-          isDrawerOpen ? 'auto' : 'no-hide-descendants'
-        }
-        accessibilityRole="button"
-        accessibilityLabel="Navigation bar expanded"
-        {...{tooltip: 'Collapse Menu'}}
-        style={styles.menu}
-        onPress={() => props.navigation.closeDrawer()}
-        activeOpacity={0.5783}
-        underlayColor="rgba(0, 0, 0, 0.0241);">
-        <Text style={styles.icon}>&#xE700;</Text>
-      </TouchableHighlight>
-      <DrawerItem
-        importantForAccessibility={
-          isDrawerOpen ? 'auto' : 'no-hide-descendants'
-        }
-        label={() => {
-          return <Text style={styles.drawerText}>Home</Text>;
-        }}
-        onPress={() => props.navigation.navigate('Home')}
-        icon={() => {
-          return <Text style={styles.icon}>&#xE80F;</Text>;
-        }}
-        style={styles.drawerBottomDivider}
-        accessibilityLabel={'home'}
-      />
-      <ScrollView {...props}>{RenderDrawer(props)}</ScrollView>
-      <DrawerItem
-        importantForAccessibility={
-          isDrawerOpen ? 'auto' : 'no-hide-descendants'
-        }
-        label={() => {
-          return <Text style={styles.drawerText}>Settings</Text>;
-        }}
-        onPress={() => props.navigation.navigate('Settings')}
-        icon={() => {
-          return <Text style={styles.icon}>&#xE713;</Text>;
-        }}
-        style={styles.drawerTopDivider}
-        accessibilityLabel={'settings'}
-      />
+    <View>
+      {RenderDrawerItem({navigation}, 0)}
+      <ScrollView style={styles.drawer}>{items}</ScrollView>
+      {RenderDrawerItem({navigation}, 1)}
     </View>
   );
 }
 
-const Drawer = createDrawerNavigator();
-
-function MyDrawer() {
-  let screens = renderScreens();
-  return (
-    <Drawer.Navigator
-      drawerContent={(props) => (
-        <CustomDrawerContent {...props} drawerType="permanent" />
-      )}>
-      {screens}
-    </Drawer.Navigator>
-  );
-}
+const Stack = createStackNavigator();
 
 function renderScreens() {
   const items = [];
@@ -218,7 +174,7 @@ function renderScreens() {
 
 function renderScreen(i: number) {
   return (
-    <Drawer.Screen
+    <Stack.Screen
       name={RNGalleryList[i].key}
       key={RNGalleryList[i].key}
       component={RNGalleryScreenWrapper}
@@ -226,11 +182,24 @@ function renderScreen(i: number) {
   );
 }
 
+function MyStack() {
+  let screens = renderScreens();
+  return <Stack.Navigator headerMode="none">{screens}</Stack.Navigator>;
+}
+
 export default function App(props) {
   const [rawtheme, setRawTheme] = React.useState<ThemeMode>('system');
   const colorScheme = useColorScheme();
   const theme = rawtheme === 'system' ? colorScheme! : rawtheme;
   appVersion = `${props.MajorVersion}.${props.MinorVersion}.${props.BuildVersion}.${props.RevisionVersion}`;
+  const state = useNavigationState((newState) => newState);
+  const entry = RNGalleryList.find(
+    (entry) => entry.key === state.routes[state.index].name,
+  );
+  console.log(state);
+  const Component = entry?.component;
+  //const Component = RNGalleryList[state.routes[state.index].name].component;
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   const [isHighContrast, setHighContrast] = React.useState(
     AppTheme.isHighContrast,
@@ -256,7 +225,42 @@ export default function App(props) {
                 ? DarkTheme
                 : LightTheme
             }>
-            <MyDrawer />
+            <View style={styles.container}>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Navigation bar"
+                accessibilityState={{expanded: isDrawerOpen}}
+                style={{
+                  backgroundColor: PlatformColor(
+                    'NavigationViewDefaultPaneBackground',
+                  ),
+                  width: isDrawerOpen ? 200 : 48,
+                  height: '100%',
+                }}
+                onPress={() => {
+                  isDrawerOpen ? setIsDrawerOpen(false) : setIsDrawerOpen(true);
+                }}>
+                <View>
+                  <TouchableHighlight
+                    accessibilityRole="button"
+                    accessibilityLabel="Navigation bar hamburger icon"
+                    {...{tooltip: 'Expand Menu'}}
+                    accessibilityState={{expanded: isDrawerOpen}}
+                    style={styles.menu}
+                    onPress={() =>
+                      isDrawerOpen
+                        ? setIsDrawerOpen(false)
+                        : setIsDrawerOpen(true)
+                    }
+                    activeOpacity={0.5783}
+                    underlayColor="rgba(0, 0, 0, 0.0241);">
+                    <Text style={styles.icon}>&#xE700;</Text>
+                  </TouchableHighlight>
+                </View>
+              </Pressable>
+              <View style={styles.navItem} />
+            </View>
+            <MyStack />
           </NavigationContainer>
         </ThemeContext.Provider>
       </RawThemeContext.Provider>

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {useTheme} from '@react-navigation/native';
 import RNGalleryList from './RNGalleryList';
 import {ScrollView} from 'react-native';
+import {ScreenWrapper} from './components/ScreenWraper';
 
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -174,13 +175,13 @@ export const HomePage: React.FunctionComponent<{}> = ({navigation}) => {
   const styles = createStyles(colors);
 
   return (
-    <View style={styles.container}>
+    <ScreenWrapper style={styles.container}>
       <Text style={styles.title}>Welcome to React Native Gallery!</Text>
       <Text style={styles.description}>
         React Native Gallery is a React Native Windows application which
         displays the range of React Native components with Windows support.
       </Text>
       <RenderPageContent navigation={navigation} />
-    </View>
+    </ScreenWrapper>
   );
 };

--- a/src/SettingsPage.tsx
+++ b/src/SettingsPage.tsx
@@ -10,6 +10,8 @@ import {
   TextDecorations,
 } from 'react-native-xaml';
 import {useTheme} from '@react-navigation/native';
+import {ScreenWrapper} from './components/ScreenWraper';
+import {Screen} from 'react-native-screens';
 var pkg = require('../package.json');
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -69,7 +71,7 @@ export const SettingsPage: React.FunctionComponent<{}> = (props) => {
     setTheme(value);
   };*/
   return (
-    <View style={styles.container}>
+    <ScreenWrapper style={styles.container}>
       <Text style={styles.title}>Settings</Text>
       <ScrollView style={styles.scrollView}>
         {/* Tracking Issue: #17
@@ -95,7 +97,7 @@ export const SettingsPage: React.FunctionComponent<{}> = (props) => {
             To clone this source repository: git clone
             https://github.com/microsoft/react-native-gallery
           </Text>
-          <Text style={styles.text}>Version: {props.appVersion}</Text>
+          <Text style={styles.text}>Version: 1.0.13.0</Text>
           <Text style={styles.text}>
             React Native Windows Version:{' '}
             {pkg.dependencies['react-native-windows']}
@@ -163,6 +165,6 @@ export const SettingsPage: React.FunctionComponent<{}> = (props) => {
           </HyperlinkButton>
         </SettingContainer>
       </ScrollView>
-    </View>
+    </ScreenWrapper>
   );
 };

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -5,6 +5,7 @@ import {CoreComponentBadge} from './CoreComponentBadge';
 import {CommunityModuleBadge} from './CommunityModuleBadge';
 import {LinkContainer} from './LinkContainer';
 import {useTheme} from '@react-navigation/native';
+import {ScreenWrapper} from './ScreenWraper';
 
 const styles = StyleSheet.create({
   container: {
@@ -90,7 +91,7 @@ export function Page(props: {
 }) {
   const {colors} = useTheme();
   return (
-    <View style={styles.container}>
+    <ScreenWrapper style={styles.container}>
       <View style={styles.titlePane}>
         <Text style={[styles.title, {color: colors.text}]}>{props.title}</Text>
         <View>
@@ -113,6 +114,6 @@ export function Page(props: {
           props.documentation,
         )}
       </ScrollView>
-    </View>
+    </ScreenWrapper>
   );
 }

--- a/src/components/ScreenWraper.tsx
+++ b/src/components/ScreenWraper.tsx
@@ -1,18 +1,18 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {
   View,
   StyleSheet,
   TouchableHighlight,
   Text,
-  useColorScheme,
-  ScrollView,
   Pressable,
 } from 'react-native';
-import RNGalleryList from '../RNGalleryList';
 import {PlatformColor} from 'react-native';
-import {useNavigation, useNavigationState} from '@react-navigation/native';
-
-let appVersion = '';
+import {
+  useNavigation,
+  DrawerActions,
+  useNavigationState,
+} from '@react-navigation/native';
+import {getIsDrawerOpenFromState} from '@react-navigation/drawer';
 
 const styles = StyleSheet.create({
   container: {
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
     flexShrink: 1,
     height: '100%',
     alignSelf: 'stretch',
-    paddingLeft: 10,
+    paddingLeft: 15,
   },
   menu: {
     margin: 5,
@@ -40,106 +40,45 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: PlatformColor('TextControlForeground'),
   },
-  drawer: {
-    backgroundColor: PlatformColor('NavigationViewDefaultPaneBackground'),
-    height: '100%',
-  },
-  drawerItem: {
-    padding: 10,
-    height: 40,
-    flexDirection: 'row',
-    paddingLeft: 15,
-  },
-  drawerText: {
-    color: PlatformColor('TextControlForeground'),
-    paddingLeft: 10,
-  },
-  drawerTopDivider: {
-    borderTopWidth: 0.5,
-    borderColor: PlatformColor('TextControlForeground'),
-    borderRadius: 0,
-  },
-  drawerBottomDivider: {
-    borderBottomWidth: 0.5,
-    borderColor: PlatformColor('TextControlForeground'),
-    borderRadius: 0,
-  },
 });
 
 // @ts-ignore
 export function ScreenWrapper({children}) {
-  //const navigation = useNavigation();
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const navigation = useNavigation();
+  const state = useNavigationState((state) => state);
 
   return (
     <View style={styles.container}>
       <Pressable
         accessibilityRole="button"
         accessibilityLabel="Navigation bar"
-        accessibilityState={{expanded: isDrawerOpen}}
+        accessibilityState={{
+          expanded: getIsDrawerOpenFromState(state),
+        }}
         style={{
           backgroundColor: PlatformColor('NavigationViewDefaultPaneBackground'),
-          width: isDrawerOpen ? 200 : 48,
+          width: 48,
           height: '100%',
+          paddingBottom: 20,
         }}
         onPress={() => {
-          isDrawerOpen ? setIsDrawerOpen(false) : setIsDrawerOpen(true);
+          navigation.dispatch(DrawerActions.openDrawer());
         }}>
         <View>
           <TouchableHighlight
             accessibilityRole="button"
             accessibilityLabel="Navigation bar hamburger icon"
             {...{tooltip: 'Expand Menu'}}
-            accessibilityState={{expanded: isDrawerOpen}}
+            accessibilityState={{expanded: getIsDrawerOpenFromState(state)}}
             style={styles.menu}
-            onPress={() =>
-              isDrawerOpen ? setIsDrawerOpen(false) : setIsDrawerOpen(true)
-            }
+            onPress={() => navigation.dispatch(DrawerActions.openDrawer())}
             activeOpacity={0.5783}
             underlayColor="rgba(0, 0, 0, 0.0241);">
             <Text style={styles.icon}>&#xE700;</Text>
           </TouchableHighlight>
-          {RenderDrawer(isDrawerOpen)}
         </View>
       </Pressable>
       <View style={styles.navItem}>{children}</View>
-    </View>
-  );
-}
-
-function RenderDrawerItem(i: number) {
-  //const isDrawerOpen = getIsDrawerOpenFromState(props.navigation.getState());
-  const navigation = useNavigation();
-  return (
-    <Pressable
-      //importantForAccessibility={isDrawerOpen ? 'auto' : 'no-hide-descendants'}
-      key={RNGalleryList[i].key}
-      onPress={() => {
-        navigation.navigate(RNGalleryList[i].key);
-      }}
-      accessibilityLabel={RNGalleryList[i].key}
-      style={styles.drawerItem}>
-      <Text style={styles.icon}>{RNGalleryList[i].icon}</Text>
-      <Text style={styles.drawerText}>{RNGalleryList[i].key}</Text>
-    </Pressable>
-  );
-}
-
-function RenderDrawer(isDrawerOpen: boolean) {
-  if (!isDrawerOpen) {
-    return [];
-  }
-  var items = [];
-  // Begin iteration at index 2 because Home and
-  // Settings drawer items have already been manually loaded.
-  for (var i = 2; i < RNGalleryList.length; i++) {
-    items.push(RenderDrawerItem(i));
-  }
-  return (
-    <View>
-      {RenderDrawerItem(0)}
-      <ScrollView style={styles.drawer}>{items}</ScrollView>
-      {RenderDrawerItem(1)}
     </View>
   );
 }

--- a/src/components/ScreenWraper.tsx
+++ b/src/components/ScreenWraper.tsx
@@ -8,27 +8,9 @@ import {
   ScrollView,
   Pressable,
 } from 'react-native';
-import {NavigationContainer, useNavigation} from '@react-navigation/native';
-import {
-  createDrawerNavigator,
-  DrawerItem,
-  getIsDrawerOpenFromState,
-  DrawerContentScrollView,
-  DrawerItemList,
-} from '@react-navigation/drawer';
-import {createStackNavigator} from '@react-navigation/stack';
-import RNGalleryList from './RNGalleryList';
-import LightTheme from './themes/LightTheme';
-import DarkTheme from './themes/DarkTheme';
-import {
-  ThemeMode,
-  RawThemeContext,
-  ThemeContext,
-  ThemeSetterContext,
-} from './themes/Theme';
+import RNGalleryList from '../RNGalleryList';
 import {PlatformColor} from 'react-native';
-import {AppTheme} from 'react-native-windows';
-import HighContrastTheme from './themes/HighContrastTheme';
+import {useNavigation, useNavigationState} from '@react-navigation/native';
 
 let appVersion = '';
 
@@ -85,8 +67,7 @@ const styles = StyleSheet.create({
 });
 
 // @ts-ignore
-function RNGalleryScreenWrapper(i: number) {
-  const Component = RNGalleryList[i].component;
+export function ScreenWrapper({children}) {
   //const navigation = useNavigation();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
@@ -121,21 +102,21 @@ function RNGalleryScreenWrapper(i: number) {
           {RenderDrawer(isDrawerOpen)}
         </View>
       </Pressable>
-      <View style={styles.navItem}>
-        <Component appVersion={appVersion} />
-      </View>
+      <View style={styles.navItem}>{children}</View>
     </View>
   );
 }
 
 function RenderDrawerItem(i: number) {
   //const isDrawerOpen = getIsDrawerOpenFromState(props.navigation.getState());
-  //const navigation = useNavigation();
+  const navigation = useNavigation();
   return (
     <Pressable
       //importantForAccessibility={isDrawerOpen ? 'auto' : 'no-hide-descendants'}
       key={RNGalleryList[i].key}
-      //onPress={() => navigation.navigate(RNGalleryList[i].key)}
+      onPress={() => {
+        navigation.navigate(RNGalleryList[i].key);
+      }}
       accessibilityLabel={RNGalleryList[i].key}
       style={styles.drawerItem}>
       <Text style={styles.icon}>{RNGalleryList[i].icon}</Text>
@@ -145,7 +126,6 @@ function RenderDrawerItem(i: number) {
 }
 
 function RenderDrawer(isDrawerOpen: boolean) {
-  //const navigation = useNavigation();
   if (!isDrawerOpen) {
     return [];
   }
@@ -161,69 +141,5 @@ function RenderDrawer(isDrawerOpen: boolean) {
       <ScrollView style={styles.drawer}>{items}</ScrollView>
       {RenderDrawerItem(1)}
     </View>
-  );
-}
-
-const Stack = createStackNavigator();
-
-function renderScreens() {
-  const items = [];
-  for (var i = 0; i < RNGalleryList.length; i++) {
-    items.push(renderScreen(i));
-  }
-
-  return items;
-}
-
-function renderScreen(i: number) {
-  return (
-    <Stack.Screen
-      name={RNGalleryList[i].key}
-      key={RNGalleryList[i].key}
-      component={RNGalleryList[i].component}
-    />
-  );
-}
-
-function MyStack() {
-  let screens = renderScreens();
-  return <Stack.Navigator headerMode="none">{screens}</Stack.Navigator>;
-}
-
-export default function App(props) {
-  const [rawtheme, setRawTheme] = React.useState<ThemeMode>('system');
-  const colorScheme = useColorScheme();
-  const theme = rawtheme === 'system' ? colorScheme! : rawtheme;
-  appVersion = `${props.MajorVersion}.${props.MinorVersion}.${props.BuildVersion}.${props.RevisionVersion}`;
-
-  const [isHighContrast, setHighContrast] = React.useState(
-    AppTheme.isHighContrast,
-  );
-
-  React.useEffect(() => {
-    const subscription = AppTheme.addListener('highContrastChanged', () => {
-      setHighContrast(AppTheme.isHighContrast);
-    });
-
-    return () => subscription.remove();
-  });
-
-  return (
-    <ThemeSetterContext.Provider value={setRawTheme}>
-      <RawThemeContext.Provider value={rawtheme}>
-        <ThemeContext.Provider value={theme}>
-          <NavigationContainer
-            theme={
-              isHighContrast
-                ? HighContrastTheme
-                : theme === 'dark'
-                ? DarkTheme
-                : LightTheme
-            }>
-            <MyStack />
-          </NavigationContainer>
-        </ThemeContext.Provider>
-      </RawThemeContext.Provider>
-    </ThemeSetterContext.Provider>
   );
 }

--- a/src/examples/ViewExamplePage.tsx
+++ b/src/examples/ViewExamplePage.tsx
@@ -1,5 +1,5 @@
 'use strict';
-import {View} from 'react-native';
+import {TextInput, View} from 'react-native';
 import React, {useState} from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
@@ -21,7 +21,7 @@ export const ViewExamplePage: React.FunctionComponent<{}> = () => {
     height: 50,
     width: 100,
   }}>
-  <View style={{flex: 1, backgroundColor: colros.text, borderRadius: 2}} />
+  <View style={{flex: 1, backgroundColor: colors.text, borderRadius: 2}} />
   <View
     style={{flex: 2, backgroundColor: colors.primary, borderRadius: 2}} />
 </View>`;
@@ -171,7 +171,10 @@ style={{
             backgroundColor: colors.text,
             borderRadius: 2,
           }}
-        />
+          accessible={true}
+          focusable={true}>
+          <TextInput />
+        </View>
       </Example>
       <Example title="Nested Views with flexbox styling." code={example3jsx}>
         <View


### PR DESCRIPTION
## Description

### Why

React Native Gallery currently has the issue where the UIA has n copies of the currently mounted page where n is the number of pages that have been navigated to during the app's lifetime. This is incorrect behavior.

### What

Using RNGalleryScreenWrapper to wrap screen upon adding them to the navigation is not legal behavior for the react navigation module. When a new screen is navigated to all screens on the stack are reloaded. Using the current index to determine which screen to wrap, results in the same screen being re-rendered over and over instead of each screen on the stack including the ones not currently loaded. 

Wrapping of screens has now been redone so that a hamburger menu can be displayed on all screens while UIA tree remains correct. This is done by editing the component pages themselves to be wrapped in the correct content.

## Screenshots

No visual changes.