### PR TITLE
Fix Screen Reader failing to announce “permissions is not available” text

### DIFF
--- a/src/examples/PermissionsExamplePage.tsx
+++ b/src/examples/PermissionsExamplePage.tsx
@@ -129,7 +129,7 @@ export const PermissionsExamplePage: React.FunctionComponent<{}> = () => {
         <Text style={{fontWeight: 'bold', paddingLeft: 10, color: colors.text}}>
           {perm}
         </Text>
-        <View focusable={getResultString(status) ? true : false}>
+        <View focusable={getResultString(status) ? true : false} accessible={getResultString(status) ? true : false}>
           <Text
             accessibilityLabel={getResultString(status)}
             style={{paddingLeft: 10, color: colors.text}}>

--- a/src/examples/PermissionsExamplePage.tsx
+++ b/src/examples/PermissionsExamplePage.tsx
@@ -129,7 +129,7 @@ export const PermissionsExamplePage: React.FunctionComponent<{}> = () => {
         <Text style={{fontWeight: 'bold', paddingLeft: 10, color: colors.text}}>
           {perm}
         </Text>
-        <View focusable={getResultString(status) ? true : false} accessible={getResultString(status) ? true : false}>
+        <View focusable={Boolean(getResultString(status))} accessible={Boolean(getResultString(status))}>
           <Text
             accessibilityLabel={getResultString(status)}
             style={{paddingLeft: 10, color: colors.text}}>

--- a/src/examples/PermissionsExamplePage.tsx
+++ b/src/examples/PermissionsExamplePage.tsx
@@ -129,7 +129,9 @@ export const PermissionsExamplePage: React.FunctionComponent<{}> = () => {
         <Text style={{fontWeight: 'bold', paddingLeft: 10, color: colors.text}}>
           {perm}
         </Text>
-        <View focusable={Boolean(getResultString(status))} accessible={Boolean(getResultString(status))}>
+        <View
+          focusable={Boolean(getResultString(status))}
+          accessible={Boolean(getResultString(status))}>
           <Text
             accessibilityLabel={getResultString(status)}
             style={{paddingLeft: 10, color: colors.text}}>


### PR DESCRIPTION
## Description
Narrator reads out result from pressing permission button now by adding accessible property to View

### Why
Resolves  #229