### PR TITLE
added community module logo to track player page

### DIFF
--- a/src/examples/TrackPlayerExamplePage.tsx
+++ b/src/examples/TrackPlayerExamplePage.tsx
@@ -183,6 +183,7 @@ export const TrackPlayerExamplePage: React.FunctionComponent<{}> = () => {
       title="Track Player"
       description="Provides audio playback, external media controls, chromecast support, background mode and more!"
       pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/TrackPlayerExamplePage.tsx"
+      componentType="Community"
       documentation={[
         {
           label: 'Track Player',


### PR DESCRIPTION
## Description 

Modified TrackPlayerExamplePage to make componentTyper 'community' and add the community module logo

### Why

Resolves [#210 ]

### What

Added community module logo to the top right of the Track Player page

## Screenshots
![image](https://user-images.githubusercontent.com/30995198/202578955-5bdf6fca-0021-4006-b1a5-e237fb9facad.png)

