### PR TITLE
Bump react-native-xaml to .71

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-native-tts": "ak1394/react-native-tts",
     "react-native-webview": "^11.18.2",
     "react-native-windows": "^0.70.0",
-    "react-native-xaml": "^0.0.66"
+    "react-native-xaml": "^0.0.71"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7269,10 +7269,10 @@ react-native-windows@^0.70.0:
     whatwg-fetch "^3.0.0"
     ws "^6.1.4"
 
-react-native-xaml@^0.0.66:
-  version "0.0.66"
-  resolved "https://registry.yarnpkg.com/react-native-xaml/-/react-native-xaml-0.0.66.tgz#a01018cc0b4e6f0773bf71f7b35c508d176de3f7"
-  integrity sha512-qp8JOSDtf6bz0n0F17RdVDOoTedfYLpONKjZnoONU/iWEoIinFkcJ2zvw3lHFziVISkJzFqbH2ar8hHt2ncVOw==
+react-native-xaml@^0.0.71:
+  version "0.0.71"
+  resolved "https://registry.yarnpkg.com/react-native-xaml/-/react-native-xaml-0.0.71.tgz#546a7c4549f7ecad52324332e64f307941f0352e"
+  integrity sha512-BO7La0RKOw58aT3F/Kj+hb3O3bTDF3YL0Ttxp9FTez0srH7mjb2EJPaMM/qtSZ8AF4wCWH7ji6tfWnobiMp+ng==
   dependencies:
     "@types/react" "*"
     "@types/react-native" "*"


### PR DESCRIPTION
## Description
Bumps react-native-xaml from .66 to .71

### Why

Recently, building gallery locally results in an error with C++23 with VS 2022, this has been fixed in react-native-xaml in .71.

Error Message:
`error C4996: 'std::aligned_storage_t': warning STL4034: std::aligned_storage and std::aligned_storage_t are deprecated in C++23. Prefer alignas(T) std::byte t_buff[sizeof(T)]. You can define _SILENCE_CXX23_ALIGNED_STORAGE_DEPRECATION_WARNING or _SILENCE_ALL_CXX23_DEPRECATION_WARNINGS to suppress this warning. (compiling source file C:\Users\asdf\Source\react-native-gallery\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\TurboModuleProvider.cpp)`