### PR TITLE
[React Native Gallery -> Popup]: Automatically shift focus to Popup when user invokes 'Open Popup' button

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-native-tts": "ak1394/react-native-tts",
     "react-native-webview": "^11.18.2",
     "react-native-windows": "^0.70.0",
-    "react-native-xaml": "^0.0.72"
+    "react-native-xaml": "^0.0.74"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/src/examples/PopupExamplePage.tsx
+++ b/src/examples/PopupExamplePage.tsx
@@ -1,6 +1,6 @@
 'use strict';
 import {AccessibilityInfo, Text, TextInput, TouchableHighlight, View, findNodeHandle} from 'react-native';
-import React, {useState, useRef} from 'react';
+import React, {useState, useEffect} from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
 import {Popup} from 'react-native-windows';
@@ -16,8 +16,21 @@ export const PopupExamplePage: React.FunctionComponent<{}> = () => {
 
   const popupRef : React.RefObject<Popup> = React.createRef<Popup>();
   const viewRef: React.RefObject<View> = React.createRef<View>();
-  const textInputRef: React.RefObject<TextInput> = React.createRef<TextInput>();
-  const textRef: React.RefObject<Text> = React.createRef<Text>();
+
+  useEffect(() => {
+    console.log('useEffect called')
+    if (popupRef.current?.props.isOpen) {
+      console.log('popup is open')
+      const reactTag = findNodeHandle(viewRef.current);
+      console.log(reactTag)
+      if (reactTag) { 
+        console.log('setting focus')
+        AccessibilityInfo.setAccessibilityFocus(reactTag);
+      }
+    }
+  })
+
+  
 
   const example1jsx = `<TouchableHighlight
   onPress={() => {

--- a/src/examples/PopupExamplePage.tsx
+++ b/src/examples/PopupExamplePage.tsx
@@ -18,19 +18,13 @@ export const PopupExamplePage: React.FunctionComponent<{}> = () => {
   const viewRef: React.RefObject<View> = React.createRef<View>();
 
   useEffect(() => {
-    console.log('useEffect called')
     if (popupRef.current?.props.isOpen) {
-      console.log('popup is open')
       const reactTag = findNodeHandle(viewRef.current);
-      console.log(reactTag)
-      if (reactTag) { 
-        console.log('setting focus')
+      if (reactTag) {
         AccessibilityInfo.setAccessibilityFocus(reactTag);
       }
     }
   })
-
-  
 
   const example1jsx = `<TouchableHighlight
   onPress={() => {
@@ -172,22 +166,15 @@ export const PopupExamplePage: React.FunctionComponent<{}> = () => {
           }}
           onPress={() => {
             setShowPopup1(true);
-            const reactTag = findNodeHandle(popupRef.current);
-            console.log('onPress')
-            if (reactTag) {
-              console.log('reactTag found')
-              console.log(reactTag)
-              AccessibilityInfo.setAccessibilityFocus(reactTag);
-            }
           }}
           activeOpacity={0.2}
           underlayColor={colors.border}>
           <Text style={{color: colors.text}}>Open Popup</Text>
         </TouchableHighlight>
-        <Popup accessible={true}
+        <Popup accessible
+               focusable
                accessibilityHint={'this is the popup'} 
                isOpen={showPopup1}
-               autoFocus={true}
                ref={popupRef}>
           <View
             style={{

--- a/src/examples/PopupExamplePage.tsx
+++ b/src/examples/PopupExamplePage.tsx
@@ -1,5 +1,5 @@
 'use strict';
-import {Text, TouchableHighlight, View} from 'react-native';
+import {AccessibilityInfo, Text, TextInput, TouchableHighlight, View, findNodeHandle} from 'react-native';
 import React, {useState, useRef} from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
@@ -14,7 +14,10 @@ export const PopupExamplePage: React.FunctionComponent<{}> = () => {
   const [showPopup3, setShowPopup3] = useState(false);
   const [showPopup4, setShowPopup4] = useState(false);
 
-  const myRef = useRef();
+  const popupRef : React.RefObject<Popup> = React.createRef<Popup>();
+  const viewRef: React.RefObject<View> = React.createRef<View>();
+  const textInputRef: React.RefObject<TextInput> = React.createRef<TextInput>();
+  const textRef: React.RefObject<Text> = React.createRef<Text>();
 
   const example1jsx = `<TouchableHighlight
   onPress={() => {
@@ -156,12 +159,23 @@ export const PopupExamplePage: React.FunctionComponent<{}> = () => {
           }}
           onPress={() => {
             setShowPopup1(true);
+            const reactTag = findNodeHandle(popupRef.current);
+            console.log('onPress')
+            if (reactTag) {
+              console.log('reactTag found')
+              console.log(reactTag)
+              AccessibilityInfo.setAccessibilityFocus(reactTag);
+            }
           }}
           activeOpacity={0.2}
           underlayColor={colors.border}>
           <Text style={{color: colors.text}}>Open Popup</Text>
         </TouchableHighlight>
-        <Popup isOpen={showPopup1}>
+        <Popup accessible={true}
+               accessibilityHint={'this is the popup'} 
+               isOpen={showPopup1}
+               autoFocus={true}
+               ref={popupRef}>
           <View
             style={{
               backgroundColor: colors.background,
@@ -170,7 +184,10 @@ export const PopupExamplePage: React.FunctionComponent<{}> = () => {
               borderRadius: 3,
               alignItems: 'center',
               justifyContent: 'space-around',
-            }}>
+            }}
+            accessible={true}
+            focusable={true}
+            ref={viewRef}>
             <Text style={{color: colors.text}}>This is a popup.</Text>
             <TouchableHighlight
               accessibilityRole="button"
@@ -329,7 +346,6 @@ export const PopupExamplePage: React.FunctionComponent<{}> = () => {
           onPress={() => {
             setShowPopup4(true);
           }}
-          ref={myRef}
           activeOpacity={0.2}
           underlayColor={colors.border}>
           <Text style={{color: colors.text}}>Open Popup</Text>
@@ -338,8 +354,7 @@ export const PopupExamplePage: React.FunctionComponent<{}> = () => {
           isOpen={showPopup4}
           onDismiss={() => {
             setShowPopup4(false);
-          }}
-          target={myRef.current}>
+          }}>
           <View
             style={{
               backgroundColor: colors.background,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7269,10 +7269,10 @@ react-native-windows@^0.70.0:
     whatwg-fetch "^3.0.0"
     ws "^6.1.4"
 
-react-native-xaml@^0.0.71:
-  version "0.0.71"
-  resolved "https://registry.yarnpkg.com/react-native-xaml/-/react-native-xaml-0.0.71.tgz#546a7c4549f7ecad52324332e64f307941f0352e"
-  integrity sha512-BO7La0RKOw58aT3F/Kj+hb3O3bTDF3YL0Ttxp9FTez0srH7mjb2EJPaMM/qtSZ8AF4wCWH7ji6tfWnobiMp+ng==
+react-native-xaml@^0.0.74:
+  version "0.0.74"
+  resolved "https://registry.yarnpkg.com/react-native-xaml/-/react-native-xaml-0.0.74.tgz#fc747308320eb1fda6dd69f5317bfeae37686b57"
+  integrity sha512-4F/kcx2//uUTOFJpePgRyu+yRje1lk9zSIhRUY5ZRIGXkkccS109uE9J+q5LqvMU8KuDEpDElE8n3UsYHZ0pKQ==
   dependencies:
     "@types/react" "*"
     "@types/react-native" "*"


### PR DESCRIPTION
## Description
Shift the focus to the Popup component automatically when user presses 'Open Popup' button on Popup page in Gallery. 

### Why
Resolves [#302]

### What
When the Popup page is initially opened from the home screen, Narrator focus does not automatically shift to the opened Popup when the 'Open Popup' button is invoked for the first time. Reopening the popup after the initial press will result in focus shifting automatically to the Popup.

## Screenshots

- First press after opening Popup page
Before pressing 'Open Popup':
![image](https://user-images.githubusercontent.com/30995198/230242425-91dba62a-dabf-4958-a2ef-bec36f312c8a.png)
After pressing 'Open Popup' (not focused on Popup):
![Screenshot 2023-04-05 172602](https://user-images.githubusercontent.com/30995198/230242625-6837b21a-d85e-4b1f-afd5-c36ec3a3cd3f.png)

-Subsequent presses on the Popup page
Before pressing 'Open Popup':
![image](https://user-images.githubusercontent.com/30995198/230242425-91dba62a-dabf-4958-a2ef-bec36f312c8a.png)
After pressing 'Open Popup' (focus has auto shifted to Popup):
![Screenshot 2023-04-05 172827](https://user-images.githubusercontent.com/30995198/230242822-8eb15438-cbf6-42f6-a61f-c80713e7f762.png)

Note: This happens on the first press immediately after any time the Popup page is loaded from the homepage i.e if you are in the Popup page, go back to the homepage and re-open the Popup page, focus will not shift on the first time you press the 'Open Popup' button.