### PR TITLE
Add accessibility properties to Eraser, Undo and Clear buttons on Sketch page

### DIFF
--- a/src/examples/SketchExamplePage.tsx
+++ b/src/examples/SketchExamplePage.tsx
@@ -27,7 +27,9 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
   </View>
 </View>`;
 
-  const sketchRef: React.RefObject<SketchCanvas> = React.createRef<SketchCanvas>();
+  const sketchRef: React.RefObject<SketchCanvas> = React.createRef<
+    SketchCanvas
+  >();
 
   return (
     <Page

--- a/src/examples/SketchExamplePage.tsx
+++ b/src/examples/SketchExamplePage.tsx
@@ -1,6 +1,12 @@
 'use strict';
-import {StyleSheet, Text, View, TouchableHighlight, Pressable} from 'react-native';
-import React, { useState } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableHighlight,
+  Pressable,
+} from 'react-native';
+import React, {useState} from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
 import {SketchCanvas} from '@wwimmo/react-native-sketch-canvas';
@@ -21,33 +27,35 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
   </View>
 </View>`;
 
-  const sketchRef : React.RefObject<SketchCanvas> = React.createRef<SketchCanvas>();
-  
+  const sketchRef: React.RefObject<SketchCanvas> = React.createRef<
+    SketchCanvas
+  >();
+
   const undoComponent = (
-    <View 
+    <View
       accessible
       accessibilityRole={'button'}
-      focusable 
+      focusable
       accessibilityLabel={'Click to undo your last action'}
       style={[styles.functionButton, {backgroundColor: colors.primary}]}>
       <Text style={{color: 'white'}}>Undo</Text>
     </View>
   );
   const clearComponent = (
-    <View 
+    <View
       accessible
       accessibilityRole={'button'}
-      focusable 
-      accessibilityLabel={'Click to clear the canvas'} 
+      focusable
+      accessibilityLabel={'Click to clear the canvas'}
       style={[styles.functionButton, {backgroundColor: colors.primary}]}>
       <Text style={{color: 'white'}}>Clear</Text>
     </View>
   );
   const eraseComponent = (
-    <View 
+    <View
       accessible
       accessibilityRole={'button'}
-      focusable 
+      focusable
       accessibilityLabel={'Click to use the eraser'}
       style={[styles.functionButton, {backgroundColor: colors.primary}]}>
       <Text style={{color: 'white'}}>Eraser</Text>
@@ -85,22 +93,23 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
       ]}>
       <Example title="A simple Sketch Canvas." code={exampleJsx}>
         <View style={{flex: 1, flexDirection: 'row', height: 250}}>
-          <SketchCanvas 
+          <SketchCanvas
             style={{backgroundColor: 'transparent', flex: 1}}
             strokeWidth={5}
             strokeColor={canvasColor}
-            ref={sketchRef}/>
+            ref={sketchRef}
+          />
         </View>
         <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
           <View style={{flexDirection: 'row', justifyContent: 'flex-start'}}>
-            <TouchableHighlight 
+            <TouchableHighlight
               style={[styles.functionButton, {backgroundColor: colors.primary}]}
               accessible
-              accessibilityRole={'button'} 
-              accessibilityLabel={'Eraser'} 
+              accessibilityRole={'button'}
+              accessibilityLabel={'Eraser'}
               onPress={() => {
                 if (sketchRef.current) {
-                  setCanvasColor('white')
+                  setCanvasColor('white');
                 }
               }}>
               <Text style={{color: 'white'}}>Eraser</Text>
@@ -110,142 +119,146 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
             <TouchableHighlight
               style={[styles.functionButton, {backgroundColor: colors.primary}]}
               accessible
-              accessibilityRole={'button'} 
-              accessibilityLabel={'Undo'} 
-              onPress={() => {sketchRef.current?.undo()}}>
-            <Text style={{color: 'white'}}>Undo</Text>
+              accessibilityRole={'button'}
+              accessibilityLabel={'Undo'}
+              onPress={() => {
+                sketchRef.current?.undo();
+              }}>
+              <Text style={{color: 'white'}}>Undo</Text>
             </TouchableHighlight>
             <TouchableHighlight
               style={[styles.functionButton, {backgroundColor: colors.primary}]}
               accessible
-              accessibilityRole={'button'} 
-              accessibilityLabel={'Clear'} 
-              onPress={() => {sketchRef.current?.clear()}}>
-            <Text style={{color: 'white'}}>Clear</Text>
+              accessibilityRole={'button'}
+              accessibilityLabel={'Clear'}
+              onPress={() => {
+                sketchRef.current?.clear();
+              }}>
+              <Text style={{color: 'white'}}>Clear</Text>
             </TouchableHighlight>
           </View>
         </View>
         <View style={{flex: 1, flexDirection: 'row'}}>
-            <Pressable
-              accessible
-              accessibilityRole={'button'}
-              accessibilityLabel={'Black'}
-              focusable
-              style={[{backgroundColor: 'black'}, styles.strokeColorButton]}
-              onPress={() => {
-                setCanvasColor('black')
-              }}
-            />
-            <Pressable
-              accessible
-              accessibilityRole={'button'}
-              accessibilityLabel={'Red'}
-              focusable
-              style={[{backgroundColor: 'red'}, styles.strokeColorButton]}
-              onPress={() => {
-                setCanvasColor('red')
-              }}
-            />
-            <Pressable
-              accessible
-              accessibilityRole={'button'}
-              accessibilityLabel={'Turquoise'}
-              focusable
-              style={[{backgroundColor: 'turquoise'}, styles.strokeColorButton]}
-              onPress={() => {
-                setCanvasColor('turquoise')
-              }}
-            />
-            <Pressable
-              accessible
-              accessibilityRole={'button'}
-              accessibilityLabel={'Blue'}
-              focusable
-              style={[{backgroundColor: 'blue'}, styles.strokeColorButton]}
-              onPress={() => {
-                setCanvasColor('blue')
-              }}
-            />
-            <Pressable
-              accessible
-              accessibilityRole={'button'}
-              accessibilityLabel={'Navy'}
-              focusable
-              style={[{backgroundColor: 'navy'}, styles.strokeColorButton]}
-              onPress={() => {
-                setCanvasColor('navy')
-              }}
-            />
-            <Pressable
-              accessible
-              accessibilityRole={'button'}
-              accessibilityLabel={'Maroon'}
-              focusable
-              style={[{backgroundColor: 'maroon'}, styles.strokeColorButton]}
-              onPress={() => {
-                setCanvasColor('maroon')
-              }}
-            />
-            <Pressable
-              accessible
-              accessibilityRole={'button'}
-              accessibilityLabel={'Green'}
-              focusable
-              style={[{backgroundColor: 'green'}, styles.strokeColorButton]}
-              onPress={() => {
-                setCanvasColor('green')
-              }}
-            />
-            <Pressable
-              accessible
-              accessibilityRole={'button'}
-              accessibilityLabel={'Fuchsia'}
-              focusable
-              style={[{backgroundColor: 'fuchsia'}, styles.strokeColorButton]}
-              onPress={() => {
-                setCanvasColor('fuchsia')
-              }}
-            />
-            <Pressable
-              accessible
-              accessibilityRole={'button'}
-              accessibilityLabel={'White'}
-              focusable
-              style={[{backgroundColor: 'white'}, styles.strokeColorButton]}
-              onPress={() => {
-                setCanvasColor('white')
-              }}
-            />
-            <Pressable
-              accessible
-              accessibilityRole={'button'}
-              accessibilityLabel={'Silver'}
-              focusable
-              style={[{backgroundColor: 'silver'}, styles.strokeColorButton]}
-              onPress={() => {
-                setCanvasColor('silver')
-              }}
-            />
-            <Pressable
-              accessible
-              accessibilityRole={'button'}
-              accessibilityLabel={'Grey'}
-              focusable
-              style={[{backgroundColor: 'grey'}, styles.strokeColorButton]}
-              onPress={() => {
-                setCanvasColor('grey')
-              }}
-            />
-            <Pressable
-              accessible
-              accessibilityRole={'button'}
-              accessibilityLabel={'Pink'}
-              focusable
-              style={[{backgroundColor: 'pink'}, styles.strokeColorButton]}
-              onPress={() => {
-                setCanvasColor('pink')
-              }}
-            />
+          <Pressable
+            accessible
+            accessibilityRole={'button'}
+            accessibilityLabel={'Black'}
+            focusable
+            style={[{backgroundColor: 'black'}, styles.strokeColorButton]}
+            onPress={() => {
+              setCanvasColor('black');
+            }}
+          />
+          <Pressable
+            accessible
+            accessibilityRole={'button'}
+            accessibilityLabel={'Red'}
+            focusable
+            style={[{backgroundColor: 'red'}, styles.strokeColorButton]}
+            onPress={() => {
+              setCanvasColor('red');
+            }}
+          />
+          <Pressable
+            accessible
+            accessibilityRole={'button'}
+            accessibilityLabel={'Turquoise'}
+            focusable
+            style={[{backgroundColor: 'turquoise'}, styles.strokeColorButton]}
+            onPress={() => {
+              setCanvasColor('turquoise');
+            }}
+          />
+          <Pressable
+            accessible
+            accessibilityRole={'button'}
+            accessibilityLabel={'Blue'}
+            focusable
+            style={[{backgroundColor: 'blue'}, styles.strokeColorButton]}
+            onPress={() => {
+              setCanvasColor('blue');
+            }}
+          />
+          <Pressable
+            accessible
+            accessibilityRole={'button'}
+            accessibilityLabel={'Navy'}
+            focusable
+            style={[{backgroundColor: 'navy'}, styles.strokeColorButton]}
+            onPress={() => {
+              setCanvasColor('navy');
+            }}
+          />
+          <Pressable
+            accessible
+            accessibilityRole={'button'}
+            accessibilityLabel={'Maroon'}
+            focusable
+            style={[{backgroundColor: 'maroon'}, styles.strokeColorButton]}
+            onPress={() => {
+              setCanvasColor('maroon');
+            }}
+          />
+          <Pressable
+            accessible
+            accessibilityRole={'button'}
+            accessibilityLabel={'Green'}
+            focusable
+            style={[{backgroundColor: 'green'}, styles.strokeColorButton]}
+            onPress={() => {
+              setCanvasColor('green');
+            }}
+          />
+          <Pressable
+            accessible
+            accessibilityRole={'button'}
+            accessibilityLabel={'Fuchsia'}
+            focusable
+            style={[{backgroundColor: 'fuchsia'}, styles.strokeColorButton]}
+            onPress={() => {
+              setCanvasColor('fuchsia');
+            }}
+          />
+          <Pressable
+            accessible
+            accessibilityRole={'button'}
+            accessibilityLabel={'White'}
+            focusable
+            style={[{backgroundColor: 'white'}, styles.strokeColorButton]}
+            onPress={() => {
+              setCanvasColor('white');
+            }}
+          />
+          <Pressable
+            accessible
+            accessibilityRole={'button'}
+            accessibilityLabel={'Silver'}
+            focusable
+            style={[{backgroundColor: 'silver'}, styles.strokeColorButton]}
+            onPress={() => {
+              setCanvasColor('silver');
+            }}
+          />
+          <Pressable
+            accessible
+            accessibilityRole={'button'}
+            accessibilityLabel={'Grey'}
+            focusable
+            style={[{backgroundColor: 'grey'}, styles.strokeColorButton]}
+            onPress={() => {
+              setCanvasColor('grey');
+            }}
+          />
+          <Pressable
+            accessible
+            accessibilityRole={'button'}
+            accessibilityLabel={'Pink'}
+            focusable
+            style={[{backgroundColor: 'pink'}, styles.strokeColorButton]}
+            onPress={() => {
+              setCanvasColor('pink');
+            }}
+          />
         </View>
       </Example>
     </Page>
@@ -263,7 +276,7 @@ const styles = StyleSheet.create({
   functionButton: {
     marginHorizontal: 2.5,
     marginVertical: 8,
-    padding: 5  ,
+    padding: 5,
     justifyContent: 'center',
     alignItems: 'center',
     borderRadius: 5,

--- a/src/examples/SketchExamplePage.tsx
+++ b/src/examples/SketchExamplePage.tsx
@@ -27,57 +27,7 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
   </View>
 </View>`;
 
-  const sketchRef: React.RefObject<SketchCanvas> = React.createRef<
-    SketchCanvas
-  >();
-
-  const undoComponent = (
-    <View
-      accessible
-      accessibilityRole={'button'}
-      focusable
-      accessibilityLabel={'Click to undo your last action'}
-      style={[styles.functionButton, {backgroundColor: colors.primary}]}>
-      <Text style={{color: 'white'}}>Undo</Text>
-    </View>
-  );
-  const clearComponent = (
-    <View
-      accessible
-      accessibilityRole={'button'}
-      focusable
-      accessibilityLabel={'Click to clear the canvas'}
-      style={[styles.functionButton, {backgroundColor: colors.primary}]}>
-      <Text style={{color: 'white'}}>Clear</Text>
-    </View>
-  );
-  const eraseComponent = (
-    <View
-      accessible
-      accessibilityRole={'button'}
-      focusable
-      accessibilityLabel={'Click to use the eraser'}
-      style={[styles.functionButton, {backgroundColor: colors.primary}]}>
-      <Text style={{color: 'white'}}>Eraser</Text>
-    </View>
-  );
-
-  const strokeComponent = (color: string) => (
-    <View style={[{backgroundColor: color}, styles.strokeColorButton]} />
-  );
-
-  const strokeSelectedComponent = (
-    color: string,
-    _index: number,
-    _changed: boolean,
-  ) => (
-    <View
-      style={[
-        {backgroundColor: color, borderWidth: 2},
-        styles.strokeColorButton,
-      ]}
-    />
-  );
+  const sketchRef: React.RefObject<SketchCanvas> = React.createRef<SketchCanvas>();
 
   return (
     <Page

--- a/src/examples/SketchExamplePage.tsx
+++ b/src/examples/SketchExamplePage.tsx
@@ -20,17 +20,29 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
 </View>`;
 
   const undoComponent = (
-    <View style={[styles.functionButton, {backgroundColor: colors.primary}]}>
+    <View 
+      accessible 
+      focusable 
+      accessibilityLabel={'Click to undo your last action'}
+      style={[styles.functionButton, {backgroundColor: colors.primary}]}>
       <Text style={{color: 'white'}}>Undo</Text>
     </View>
   );
   const clearComponent = (
-    <View style={[styles.functionButton, {backgroundColor: colors.primary}]}>
+    <View 
+      accessible 
+      focusable 
+      accessibilityLabel={'Click to clear the canvas'} 
+      style={[styles.functionButton, {backgroundColor: colors.primary}]}>
       <Text style={{color: 'white'}}>Clear</Text>
     </View>
   );
   const eraseComponent = (
-    <View style={[styles.functionButton, {backgroundColor: colors.primary}]}>
+    <View 
+      accessible 
+      focusable 
+      accessibilityLabel={'Click to use the eraser'}
+      style={[styles.functionButton, {backgroundColor: colors.primary}]}>
       <Text style={{color: 'white'}}>Eraser</Text>
     </View>
   );

--- a/src/examples/SketchExamplePage.tsx
+++ b/src/examples/SketchExamplePage.tsx
@@ -1,9 +1,9 @@
 'use strict';
-import {StyleSheet, Text, View, TouchableHighlight} from 'react-native';
+import {StyleSheet, Text, View, TouchableHighlight, Pressable} from 'react-native';
 import React, { useState } from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
-import {RNSketchCanvas, SketchCanvas} from '@wwimmo/react-native-sketch-canvas';
+import {SketchCanvas} from '@wwimmo/react-native-sketch-canvas';
 import {useTheme} from '@react-navigation/native';
 
 export const SketchExamplePage: React.FunctionComponent<{}> = () => {
@@ -71,18 +71,6 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
     />
   );
 
-{/*       <RNSketchCanvas
-            containerStyle={{backgroundColor: 'transparent', flex: 1}}
-            canvasStyle={{backgroundColor: 'transparent', flex: 1}}
-            undoComponent={undoComponent}
-            clearComponent={clearComponent}
-            eraseComponent={eraseComponent}
-            strokeComponent={strokeComponent}
-            strokeSelectedComponent={strokeSelectedComponent}
-            defaultStrokeIndex={0}
-            defaultStrokeWidth={5}
-          /> */}
-
   return (
     <Page
       title="Sketch Canvas"
@@ -103,36 +91,161 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
             strokeColor={canvasColor}
             ref={sketchRef}/>
         </View>
-        <View 
-          style={{flexDirection: 'row'}}>
-          <TouchableHighlight 
-            style={[styles.functionButton, {backgroundColor: colors.primary}]}
-            accessible
-            accessibilityRole={'button'} 
-            accessibilityLabel={'Clear'} 
-            onPress={() => {
-              if (sketchRef.current) {
+        <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
+          <View style={{flexDirection: 'row', justifyContent: 'flex-start'}}>
+            <TouchableHighlight 
+              style={[styles.functionButton, {backgroundColor: colors.primary}]}
+              accessible
+              accessibilityRole={'button'} 
+              accessibilityLabel={'Eraser'} 
+              onPress={() => {
+                if (sketchRef.current) {
+                  setCanvasColor('white')
+                }
+              }}>
+              <Text style={{color: 'white'}}>Eraser</Text>
+            </TouchableHighlight>
+          </View>
+          <View style={{flexDirection: 'row', justifyContent: 'flex-end'}}>
+            <TouchableHighlight
+              style={[styles.functionButton, {backgroundColor: colors.primary}]}
+              accessible
+              accessibilityRole={'button'} 
+              accessibilityLabel={'Undo'} 
+              onPress={() => {sketchRef.current?.undo()}}>
+            <Text style={{color: 'white'}}>Undo</Text>
+            </TouchableHighlight>
+            <TouchableHighlight
+              style={[styles.functionButton, {backgroundColor: colors.primary}]}
+              accessible
+              accessibilityRole={'button'} 
+              accessibilityLabel={'Clear'} 
+              onPress={() => {sketchRef.current?.clear()}}>
+            <Text style={{color: 'white'}}>Clear</Text>
+            </TouchableHighlight>
+          </View>
+        </View>
+        <View style={{flex: 1, flexDirection: 'row'}}>
+            <Pressable
+              accessible
+              accessibilityRole={'button'}
+              accessibilityLabel={'Black'}
+              focusable
+              style={[{backgroundColor: 'black'}, styles.strokeColorButton]}
+              onPress={() => {
+                setCanvasColor('black')
+              }}
+            />
+            <Pressable
+              accessible
+              accessibilityRole={'button'}
+              accessibilityLabel={'Red'}
+              focusable
+              style={[{backgroundColor: 'red'}, styles.strokeColorButton]}
+              onPress={() => {
+                setCanvasColor('red')
+              }}
+            />
+            <Pressable
+              accessible
+              accessibilityRole={'button'}
+              accessibilityLabel={'Turquoise'}
+              focusable
+              style={[{backgroundColor: 'turquoise'}, styles.strokeColorButton]}
+              onPress={() => {
+                setCanvasColor('turquoise')
+              }}
+            />
+            <Pressable
+              accessible
+              accessibilityRole={'button'}
+              accessibilityLabel={'Blue'}
+              focusable
+              style={[{backgroundColor: 'blue'}, styles.strokeColorButton]}
+              onPress={() => {
+                setCanvasColor('blue')
+              }}
+            />
+            <Pressable
+              accessible
+              accessibilityRole={'button'}
+              accessibilityLabel={'Navy'}
+              focusable
+              style={[{backgroundColor: 'navy'}, styles.strokeColorButton]}
+              onPress={() => {
+                setCanvasColor('navy')
+              }}
+            />
+            <Pressable
+              accessible
+              accessibilityRole={'button'}
+              accessibilityLabel={'Maroon'}
+              focusable
+              style={[{backgroundColor: 'maroon'}, styles.strokeColorButton]}
+              onPress={() => {
+                setCanvasColor('maroon')
+              }}
+            />
+            <Pressable
+              accessible
+              accessibilityRole={'button'}
+              accessibilityLabel={'Green'}
+              focusable
+              style={[{backgroundColor: 'green'}, styles.strokeColorButton]}
+              onPress={() => {
+                setCanvasColor('green')
+              }}
+            />
+            <Pressable
+              accessible
+              accessibilityRole={'button'}
+              accessibilityLabel={'Fuchsia'}
+              focusable
+              style={[{backgroundColor: 'fuchsia'}, styles.strokeColorButton]}
+              onPress={() => {
+                setCanvasColor('fuchsia')
+              }}
+            />
+            <Pressable
+              accessible
+              accessibilityRole={'button'}
+              accessibilityLabel={'White'}
+              focusable
+              style={[{backgroundColor: 'white'}, styles.strokeColorButton]}
+              onPress={() => {
                 setCanvasColor('white')
-              }
-            }}>
-          <Text style={{color: 'white'}}>Eraser</Text>
-          </TouchableHighlight>
-          <TouchableHighlight
-            style={[styles.functionButton, {backgroundColor: colors.primary}]}
-            accessible
-            accessibilityRole={'button'} 
-            accessibilityLabel={'Undo'} 
-            onPress={() => {sketchRef.current?.undo()}}>
-          <Text style={{color: 'white'}}>Undo</Text>
-          </TouchableHighlight>
-          <TouchableHighlight
-            style={[styles.functionButton, {backgroundColor: colors.primary}]}
-            accessible
-            accessibilityRole={'button'} 
-            accessibilityLabel={'Clear'} 
-            onPress={() => {sketchRef.current?.clear()}}>
-          <Text style={{color: 'white'}}>Clear</Text>
-          </TouchableHighlight>
+              }}
+            />
+            <Pressable
+              accessible
+              accessibilityRole={'button'}
+              accessibilityLabel={'Silver'}
+              focusable
+              style={[{backgroundColor: 'silver'}, styles.strokeColorButton]}
+              onPress={() => {
+                setCanvasColor('silver')
+              }}
+            />
+            <Pressable
+              accessible
+              accessibilityRole={'button'}
+              accessibilityLabel={'Grey'}
+              focusable
+              style={[{backgroundColor: 'grey'}, styles.strokeColorButton]}
+              onPress={() => {
+                setCanvasColor('grey')
+              }}
+            />
+            <Pressable
+              accessible
+              accessibilityRole={'button'}
+              accessibilityLabel={'Pink'}
+              focusable
+              style={[{backgroundColor: 'pink'}, styles.strokeColorButton]}
+              onPress={() => {
+                setCanvasColor('pink')
+              }}
+            />
         </View>
       </Example>
     </Page>

--- a/src/examples/SketchExamplePage.tsx
+++ b/src/examples/SketchExamplePage.tsx
@@ -1,6 +1,6 @@
 'use strict';
 import {StyleSheet, Text, View, TouchableHighlight} from 'react-native';
-import React from 'react';
+import React, { useState } from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
 import {RNSketchCanvas, SketchCanvas} from '@wwimmo/react-native-sketch-canvas';
@@ -8,6 +8,8 @@ import {useTheme} from '@react-navigation/native';
 
 export const SketchExamplePage: React.FunctionComponent<{}> = () => {
   const {colors} = useTheme();
+
+  const [canvasColor, setCanvasColor] = useState('black');
 
   const exampleJsx = `<View style={{flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#F5FCFF'}}>
   <View style={{ flex: 1, flexDirection: 'row' }}>
@@ -98,18 +100,33 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
           <SketchCanvas 
             style={{backgroundColor: 'transparent', flex: 1}}
             strokeWidth={5}
-            ref={sketchRef}          />
+            strokeColor={canvasColor}
+            ref={sketchRef}/>
         </View>
         <View 
-          style={[styles.functionButton, {backgroundColor: colors.primary}]}>
+          style={{flexDirection: 'row'}}>
           <TouchableHighlight 
+            style={[styles.functionButton, {backgroundColor: colors.primary}]}
+            accessible
+            accessibilityRole={'button'} 
+            accessibilityLabel={'Clear'} 
+            onPress={() => {
+              if (sketchRef.current) {
+                setCanvasColor('white')
+              }
+            }}>
+          <Text style={{color: 'white'}}>Eraser</Text>
+          </TouchableHighlight>
+          <TouchableHighlight
+            style={[styles.functionButton, {backgroundColor: colors.primary}]}
             accessible
             accessibilityRole={'button'} 
             accessibilityLabel={'Undo'} 
             onPress={() => {sketchRef.current?.undo()}}>
           <Text style={{color: 'white'}}>Undo</Text>
           </TouchableHighlight>
-          <TouchableHighlight 
+          <TouchableHighlight
+            style={[styles.functionButton, {backgroundColor: colors.primary}]}
             accessible
             accessibilityRole={'button'} 
             accessibilityLabel={'Clear'} 
@@ -133,7 +150,7 @@ const styles = StyleSheet.create({
   functionButton: {
     marginHorizontal: 2.5,
     marginVertical: 8,
-    padding: 5,
+    padding: 5  ,
     justifyContent: 'center',
     alignItems: 'center',
     borderRadius: 5,

--- a/src/examples/SketchExamplePage.tsx
+++ b/src/examples/SketchExamplePage.tsx
@@ -1,9 +1,9 @@
 'use strict';
-import {StyleSheet, Text, View} from 'react-native';
+import {StyleSheet, Text, View, TouchableHighlight} from 'react-native';
 import React from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
-import RNSketchCanvas from '@wwimmo/react-native-sketch-canvas';
+import {RNSketchCanvas, SketchCanvas} from '@wwimmo/react-native-sketch-canvas';
 import {useTheme} from '@react-navigation/native';
 
 export const SketchExamplePage: React.FunctionComponent<{}> = () => {
@@ -19,6 +19,8 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
   </View>
 </View>`;
 
+  const sketchRef : React.RefObject<SketchCanvas> = React.createRef<SketchCanvas>();
+  
   const undoComponent = (
     <View 
       accessible
@@ -67,6 +69,18 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
     />
   );
 
+{/*       <RNSketchCanvas
+            containerStyle={{backgroundColor: 'transparent', flex: 1}}
+            canvasStyle={{backgroundColor: 'transparent', flex: 1}}
+            undoComponent={undoComponent}
+            clearComponent={clearComponent}
+            eraseComponent={eraseComponent}
+            strokeComponent={strokeComponent}
+            strokeSelectedComponent={strokeSelectedComponent}
+            defaultStrokeIndex={0}
+            defaultStrokeWidth={5}
+          /> */}
+
   return (
     <Page
       title="Sketch Canvas"
@@ -81,17 +95,27 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
       ]}>
       <Example title="A simple Sketch Canvas." code={exampleJsx}>
         <View style={{flex: 1, flexDirection: 'row', height: 250}}>
-          <RNSketchCanvas
-            containerStyle={{backgroundColor: 'transparent', flex: 1}}
-            canvasStyle={{backgroundColor: 'transparent', flex: 1}}
-            undoComponent={undoComponent}
-            clearComponent={clearComponent}
-            eraseComponent={eraseComponent}
-            strokeComponent={strokeComponent}
-            strokeSelectedComponent={strokeSelectedComponent}
-            defaultStrokeIndex={0}
-            defaultStrokeWidth={5}
-          />
+          <SketchCanvas 
+            style={{backgroundColor: 'transparent', flex: 1}}
+            strokeWidth={5}
+            ref={sketchRef}          />
+        </View>
+        <View 
+          style={[styles.functionButton, {backgroundColor: colors.primary}]}>
+          <TouchableHighlight 
+            accessible
+            accessibilityRole={'button'} 
+            accessibilityLabel={'Undo'} 
+            onPress={() => {sketchRef.current?.undo()}}>
+          <Text style={{color: 'white'}}>Undo</Text>
+          </TouchableHighlight>
+          <TouchableHighlight 
+            accessible
+            accessibilityRole={'button'} 
+            accessibilityLabel={'Clear'} 
+            onPress={() => {sketchRef.current?.clear()}}>
+          <Text style={{color: 'white'}}>Clear</Text>
+          </TouchableHighlight>
         </View>
       </Example>
     </Page>

--- a/src/examples/SketchExamplePage.tsx
+++ b/src/examples/SketchExamplePage.tsx
@@ -21,7 +21,8 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
 
   const undoComponent = (
     <View 
-      accessible 
+      accessible
+      accessibilityRole={'button'}
       focusable 
       accessibilityLabel={'Click to undo your last action'}
       style={[styles.functionButton, {backgroundColor: colors.primary}]}>
@@ -30,7 +31,8 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
   );
   const clearComponent = (
     <View 
-      accessible 
+      accessible
+      accessibilityRole={'button'}
       focusable 
       accessibilityLabel={'Click to clear the canvas'} 
       style={[styles.functionButton, {backgroundColor: colors.primary}]}>
@@ -39,7 +41,8 @@ export const SketchExamplePage: React.FunctionComponent<{}> = () => {
   );
   const eraseComponent = (
     <View 
-      accessible 
+      accessible
+      accessibilityRole={'button'}
       focusable 
       accessibilityLabel={'Click to use the eraser'}
       style={[styles.functionButton, {backgroundColor: colors.primary}]}>


### PR DESCRIPTION
Add properties to buttons on Sketch page so that Narrator reads accessibility cues

### Why

Resolves [#307]

### What

Added `accessible, focusable, accessibilityRole and accessibilityLabel` properties to the Eraser, Undo and Clear buttons on the Sketch page. CHanged implementation of Sketch Canvas to allow for UI customization which allowed accessibility cues to be read by narrator immediately when tabbing onto buttons.

## Screenshots

After (focus on eraser button):
![Screenshot 2023-04-12 115131](https://user-images.githubusercontent.com/30995198/231556659-02aea043-7efe-4733-9c33-67a5570d3b2e.png)
No visible difference from 'Before' example, however earlier button had to be tabbed into twice to get accessibility cues read aloud by narrator - now they are read out immediately after being tabbed into.