### PR TITLE
Bumped react-navigation/drawer 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@react-native-community/progress-view": "^1.4.0",
     "@react-native-community/slider": "^4.0.0-rc.3",
     "@react-native-picker/picker": "^2.2.1",
-    "@react-navigation/drawer": "^6.4.1",
+    "@react-navigation/drawer": "^7.0.0-alpha.0",
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/stack": "^6.3.12",
     "@types/": "react-navigation/drawer",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2549,19 +2549,25 @@
     react-is "^16.13.0"
     use-latest-callback "^0.1.5"
 
-"@react-navigation/drawer@^6.4.1":
-  version "6.5.8"
-  resolved "https://registry.yarnpkg.com/@react-navigation/drawer/-/drawer-6.5.8.tgz#1bab9f761099fefd5a3e7080851076d0b4310dac"
-  integrity sha512-24okwc1gVJex+NMwau1QfxIRUDfFvdbnwFS/N0bCUXDVu8bqsMeYA00C3xwCpvdRmANbBH4rFRniNbJLAvD4Jg==
+"@react-navigation/drawer@^7.0.0-alpha.0":
+  version "7.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/drawer/-/drawer-7.0.0-alpha.1.tgz#4b20ffa59d64d278b015f031eec3e132ac72d12b"
+  integrity sha512-YGAuGdInkR+Et+hc0hymHoSSlYp8sn5Aws91rLZ/BgMD2t0qX3z1dmgJNWn04CnIYaom1ndcKezSRlrp7XDk2A==
   dependencies:
-    "@react-navigation/elements" "^1.3.14"
+    "@react-navigation/elements" "^1.4.0-alpha.0"
     color "^4.2.3"
-    warn-once "^0.1.0"
+    react-native-drawer-layout "^3.2.0"
+    use-latest-callback "^0.1.5"
 
 "@react-navigation/elements@^1.3.14":
   version "1.3.14"
   resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.3.14.tgz#ee9ef7f57e0877700ebb359947728b255bbb9c65"
   integrity sha512-RBbPhYq+KNFPAkWPaHB9gypq0jTGp/0fkMwRLToJ8jkLtWG4LV+JoQ/erFQnVARkR3Q807n0VnES15EYP4ITMQ==
+
+"@react-navigation/elements@^1.4.0-alpha.0":
+  version "1.4.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.4.0-alpha.0.tgz#d3a26fc60fad2947776edec13dade04266a065d8"
+  integrity sha512-gsqoov/AEbBaj1MuXa9QhcEyTa9SEbeKRpFphSNGIf1ShADJQWZGIK3FOC9s5Kp9T5enV1zUWVYchbT9+U1cZg==
 
 "@react-navigation/native@^6.0.10":
   version "6.1.3"
@@ -7775,6 +7781,13 @@ react-native-device-info@^7.3.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-7.3.1.tgz#6c4b0120d57872a2f7534332323306b386828a3d"
   integrity sha512-RQP3etbmXsOlcaxHeHNug68nRli02S9iGC7TbaXpkvyyevIuRogfnrI71sWtqmlT91kdpYAOYKmNfRL9LOSKVw==
+
+react-native-drawer-layout@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-drawer-layout/-/react-native-drawer-layout-3.2.0.tgz#1ab05d0bed6bb684353c17c96e1d3e6c1a4e225d"
+  integrity sha512-d/kvzeBhXjqcRGlfkTSB96ZRKH6g6YxJK+gPtUOCOCH5piHpsupgX+tLAHdM8r8NUzN6Tl9656xfJTuVb8Zrgw==
+  dependencies:
+    use-latest-callback "^0.1.5"
 
 react-native-gesture-handler@2.9.0:
   version "2.9.0"


### PR DESCRIPTION
Updated react-navigation/drawer to include accessiblitlyLabel addition to DrawerItem props

### Why

Resolves [#309]

### What

Originally accessibilityLabel was not included as a prop consumed by DrawerItem, which is why, despited setting accessibilityLabel, all the drawer items in the Gallery navigation panel had name property as null. This change resolves the issue and allows the UIA property to read the accessibiltyLabel prop.

## Screenshots

Before:
![image](https://github.com/microsoft/react-native-gallery/assets/30995198/0aeda4b8-279f-45d5-85b5-ca64d830f19e)

After:
![image](https://github.com/microsoft/react-native-gallery/assets/30995198/c672900f-385b-4742-8c1b-582e4d46b496)
