### PR TITLE
Added header accessibilityRole to Home and Settings pages

### DIFF
--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -58,7 +58,7 @@ const HomeContainer = (props: {heading: string; children: React.ReactNode}) => {
   const styles = createStyles(colors);
   return (
     <View accessibilityLabel={props.heading + 'components'}>
-      <Text style={styles.heading}>{props.heading}</Text>
+      <Text accessibilityRole='header' style={styles.heading}>{props.heading}</Text>
       <View style={styles.homeContainer}>{props.children}</View>
     </View>
   );

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -58,7 +58,9 @@ const HomeContainer = (props: {heading: string; children: React.ReactNode}) => {
   const styles = createStyles(colors);
   return (
     <View accessibilityLabel={props.heading + 'components'}>
-      <Text accessibilityRole='header' style={styles.heading}>{props.heading}</Text>
+      <Text accessibilityRole="header" style={styles.heading}>
+        {props.heading}
+      </Text>
       <View style={styles.homeContainer}>{props.children}</View>
     </View>
   );

--- a/src/SettingsPage.tsx
+++ b/src/SettingsPage.tsx
@@ -54,7 +54,9 @@ const SettingContainer = (props: {
   const styles = createStyles(colors);
   return (
     <View>
-      <Text style={styles.heading} accessibilityRole='header'>{props.heading}</Text>
+      <Text style={styles.heading} accessibilityRole="header">
+        {props.heading}
+      </Text>
       <View style={styles.settingContainer}>{props.children}</View>
     </View>
   );
@@ -72,7 +74,9 @@ export const SettingsPage: React.FunctionComponent<{}> = (props) => {
   };*/
   return isScreenFocused ? (
     <ScreenWrapper style={styles.container}>
-      <Text accessibilityRole='header' style={styles.title}>Settings</Text>
+      <Text accessibilityRole="header" style={styles.title}>
+        Settings
+      </Text>
       <ScrollView style={styles.scrollView}>
         {/* Tracking Issue: #17
         <SettingContainer heading="Theme Mode">

--- a/src/SettingsPage.tsx
+++ b/src/SettingsPage.tsx
@@ -54,7 +54,7 @@ const SettingContainer = (props: {
   const styles = createStyles(colors);
   return (
     <View>
-      <Text style={styles.heading}>{props.heading}</Text>
+      <Text style={styles.heading} accessibilityRole='header'>{props.heading}</Text>
       <View style={styles.settingContainer}>{props.children}</View>
     </View>
   );
@@ -72,7 +72,7 @@ export const SettingsPage: React.FunctionComponent<{}> = (props) => {
   };*/
   return isScreenFocused ? (
     <ScreenWrapper style={styles.container}>
-      <Text style={styles.title}>Settings</Text>
+      <Text accessibilityRole='header' style={styles.title}>Settings</Text>
       <ScrollView style={styles.scrollView}>
         {/* Tracking Issue: #17
         <SettingContainer heading="Theme Mode">


### PR DESCRIPTION
## Description
Added header `accessibilityRole` to Home and Settings pages

### Why

Resolves #337 

### What

Added `accessibilityRole='header'` to all headings and subheadings on the Home and Settings pages in Gallery. This results in Narrator announcing 'Heading level 2' on all headings and subheadings on the respective pages.