### PR TITLE
Update bot yml to match version in samples repo

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -16,7 +16,7 @@ configuration:
       - isIssue
       - isOpen
       - hasLabel:
-          label: 'Needs: author feedback'
+          label: 'Needs: Author Feedback'
       - hasLabel:
           label: 'Status: no recent activity'
       - noActivitySince:
@@ -31,7 +31,7 @@ configuration:
       - isIssue
       - isOpen
       - hasLabel:
-          label: 'Needs: author feedback'
+          label: 'Needs: Author Feedback'
       - noActivitySince:
           days: 7
       - isNotLabeledWith:
@@ -64,7 +64,7 @@ configuration:
       - isPullRequest
       - isOpen
       - hasLabel:
-          label: 'Needs: author feedback'
+          label: 'Needs: Author Feedback'
       - hasLabel:
           label: 'Status: no recent activity'
       - noActivitySince:
@@ -79,7 +79,7 @@ configuration:
       - isPullRequest
       - isOpen
       - hasLabel:
-          label: 'Needs: author feedback'
+          label: 'Needs: Author Feedback'
       - noActivitySince:
           days: 7
       - isNotLabeledWith:
@@ -96,7 +96,7 @@ configuration:
           action: Opened
       then:
       - addLabel:
-          label: 'Needs: triage :mag:'
+          label: 'Needs: Triage :mag:'
       description: 
     - if:
       - payloadType: Issue_Comment
@@ -105,13 +105,13 @@ configuration:
       - isActivitySender:
           issueAuthor: True
       - hasLabel:
-          label: 'Needs: author feedback'
+          label: 'Needs: Author Feedback'
       - isOpen
       then:
       - addLabel:
-          label: 'Needs: attention :wave:'
+          label: 'Needs: Attention :wave:'
       - removeLabel:
-          label: 'Needs: author feedback'
+          label: 'Needs: Author Feedback'
       description: 
     - if:
       - payloadType: Issues
@@ -131,6 +131,28 @@ configuration:
       then:
       - removeLabel:
           label: 'Status: no recent activity'
+      description: 
+    - if:
+      - payloadType: Pull_Request
+      - hasLabel:
+          label: AutoMerge
+      then:
+      - enableAutoMerge:
+          mergeMethod: Squash
+      description: 
+    - if:
+      - payloadType: Pull_Request
+      - labelRemoved:
+          label: AutoMerge
+      then:
+      - disableAutoMerge
+      description: 
+    - if:
+      - payloadType: Pull_Request
+      - isAction:
+          action: Opened
+      then:
+      - addCodeFlowLink
       description: 
     - if:
       - payloadType: Pull_Request_Review
@@ -150,17 +172,17 @@ configuration:
           isAction:
             action: Closed
       - hasLabel:
-          label: 'Needs: author feedback'
+          label: 'Needs: Author Feedback'
       then:
       - removeLabel:
-          label: 'Needs: author feedback'
+          label: 'Needs: Author Feedback'
       description: 
     - if:
       - payloadType: Issue_Comment
       - isActivitySender:
           issueAuthor: True
       - hasLabel:
-          label: 'Needs: author feedback'
+          label: 'Needs: Author Feedback'
       then:
       - removeLabel:
           label: 'Needs: author feedback'
@@ -170,10 +192,10 @@ configuration:
       - isActivitySender:
           issueAuthor: True
       - hasLabel:
-          label: 'Needs: author feedback'
+          label: 'Needs: Author Feedback'
       then:
       - removeLabel:
-          label: 'Needs: author feedback'
+          label: 'Needs: Author Feedback'
       description: 
     - if:
       - payloadType: Pull_Request
@@ -203,19 +225,39 @@ configuration:
           label: 'Status: no recent activity'
       description: 
     - if:
-      - payloadType: Pull_Request
-      - hasLabel:
-          label: auto merge
+      - payloadType: Issues
+      - labelAdded:
+          label: 'Needs: Environment Info'
       then:
-      - enableAutoMerge:
-          mergeMethod: Squash
-      description: 
-    - if:
-      - payloadType: Pull_Request
-      - labelRemoved:
-          label: auto merge
-      then:
-      - disableAutoMerge
+      - addReply:
+          reply: >-
+            This issue would benefit from environment info. Please edit your issue report to add this information.
+
+
+            If you are using latest version:
+
+            1. `npx react-native --version`:
+
+            2. `npx react-native run-windows --info`:
+
+
+            Otherwise if `--info` doesn't exist:
+
+            1. `react-native -v`:
+
+            2. `npm ls rnpm-plugin-windows`:
+
+            3. `npm ls react-native-windows`:
+
+            4. `node -v`:
+
+            5. `npm -v`:
+
+            6. `yarn --version`<!-- (if you use Yarn) -->:
+      - addLabel:
+          label: 'Needs: Author Feedback'
+      - removeLabel:
+          label: 'Needs: triage :mag:'
       description: 
 onFailure: 
 onSuccess: 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -162,7 +162,7 @@ configuration:
           reviewState: Changes_requested
       then:
       - addLabel:
-          label: 'Needs: author feedback'
+          label: 'Needs: Author feedback'
       description: 
     - if:
       - payloadType: Pull_Request
@@ -185,7 +185,7 @@ configuration:
           label: 'Needs: Author Feedback'
       then:
       - removeLabel:
-          label: 'Needs: author feedback'
+          label: 'Needs: Author feedback'
       description: 
     - if:
       - payloadType: Pull_Request_Review
@@ -257,7 +257,7 @@ configuration:
       - addLabel:
           label: 'Needs: Author Feedback'
       - removeLabel:
-          label: 'Needs: triage :mag:'
+          label: 'Needs: Triage :mag:'
       description: 
 onFailure: 
 onSuccess: 


### PR DESCRIPTION
## Description

Updates the yml configuration that our bot uses for labeling/lifetime/etc.. Specifically, this takes the copy from [react-native-windows-samples](https://github.com/microsoft/react-native-windows-samples/blob/main/.github/policies/resourceManagement.yml) and copies it to Gallery.

### Why

There's not intended to be a difference between them.
Also there's been some weirdness in PRs touching this file recently and maybe it had some whitespace changes that needed a refresh?

### Other

- There are some capitalization differences in the labels. Not sure if case insensitive. But I can also just edit the labels to match (which is a good idea anyway).
- This brought in the "needs environment info" rule, which seems like goodness. May need to add the corresponding label.