### PR TITLE
Fix 'Disabled Pressable' example on Pressable page

### DIFF
--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -19364,28 +19364,7 @@ exports[`Pressable Example Page 1`] = `
                   </Text>
                   <Text>
                     }&gt;
-  {
-                  </Text>
-                  <Text
-                    style={{}}
-                  >
-                    <Text>
-                      (
-                    </Text>
-                    <Text
-                      style={{}}
-                    >
-                      <Text>
-                        {pressed}
-                      </Text>
-                    </Text>
-                    <Text>
-                      ) =&gt;
-                    </Text>
-                  </Text>
-                  <Text>
-                     (
-    
+  
                   </Text>
                   <Text
                     style={{}}
@@ -19412,7 +19391,8 @@ exports[`Pressable Example Page 1`] = `
                         </Text>
                       </Text>
                       <Text>
-                         
+                        
+    
                       </Text>
                       <Text
                         style={
@@ -19436,7 +19416,22 @@ exports[`Pressable Example Page 1`] = `
                         }
                       >
                         <Text>
-                          {{textAlign:
+                          {{
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+      
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          textAlign:
                         </Text>
                       </Text>
                       <Text>
@@ -19454,7 +19449,8 @@ exports[`Pressable Example Page 1`] = `
                         </Text>
                       </Text>
                       <Text>
-                        ', 
+                        ',
+      
                       </Text>
                       <Text
                         style={
@@ -19482,13 +19478,43 @@ exports[`Pressable Example Page 1`] = `
                         </Text>
                       </Text>
                       <Text>
-                        }}&gt;
+                        ,
+      
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          color:
+                        </Text>
+                      </Text>
+                      <Text>
+                         
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          colors.text
+                        </Text>
+                      </Text>
+                      <Text>
+                        ,
+    }}&gt;
                       </Text>
                     </Text>
                     <Text>
                       
-      {pressed ? 'This will never be triggered.' : 'Disabled Pressable'}
-    
+    Disabled Pressable
+  
                     </Text>
                     <Text
                       style={
@@ -19518,7 +19544,6 @@ exports[`Pressable Example Page 1`] = `
                   </Text>
                   <Text>
                     
-  )}
 &lt;/Pressable&gt;
                   </Text>
                 </Text>

--- a/src/examples/PressableExamplePage.tsx
+++ b/src/examples/PressableExamplePage.tsx
@@ -24,11 +24,14 @@ export const PressableExamplePage: React.FunctionComponent<{}> = () => {
     opacity: 0.5,
   }}
   disabled={true}>
-  {({pressed}) => (
-    <Text style={{textAlign: 'center', paddingVertical: 15}}>
-      {pressed ? 'This will never be triggered.' : 'Disabled Pressable'}
-    </Text>
-  )}
+  <Text
+    style={{
+      textAlign: 'center',
+      paddingVertical: 15,
+      color: colors.text,
+    }}>
+    Disabled Pressable
+  </Text>
 </Pressable>`;
 
   const example3jsx = `<Pressable
@@ -116,16 +119,14 @@ export const PressableExamplePage: React.FunctionComponent<{}> = () => {
             opacity: 0.5,
           }}
           disabled={true}>
-          {({pressed}) => (
             <Text
               style={{
                 textAlign: 'center',
                 paddingVertical: 15,
                 color: colors.text,
               }}>
-              {pressed ? 'This will never be triggered.' : 'Disabled Pressable'}
+              Disabled Pressable
             </Text>
-          )}
         </Pressable>
       </Example>
       <Example title="A Pressable component with counter." code={example3jsx}>

--- a/src/examples/PressableExamplePage.tsx
+++ b/src/examples/PressableExamplePage.tsx
@@ -119,14 +119,14 @@ export const PressableExamplePage: React.FunctionComponent<{}> = () => {
             opacity: 0.5,
           }}
           disabled={true}>
-            <Text
-              style={{
-                textAlign: 'center',
-                paddingVertical: 15,
-                color: colors.text,
-              }}>
-              Disabled Pressable
-            </Text>
+          <Text
+            style={{
+              textAlign: 'center',
+              paddingVertical: 15,
+              color: colors.text,
+            }}>
+            Disabled Pressable
+          </Text>
         </Pressable>
       </Example>
       <Example title="A Pressable component with counter." code={example3jsx}>


### PR DESCRIPTION
## Description
Change Disabled pressable example so that it no longer performs an action.

### Why

Resolves #363 

### What

Removed different display messages when Pressable was being pressed.

## Screenshots
Before: 
![Screenshot (35)](https://github.com/microsoft/react-native-gallery/assets/30995198/bd33c8dc-2920-45dd-8933-fbe2076776ff)

After:
![Screenshot (34)](https://github.com/microsoft/react-native-gallery/assets/30995198/0bcb9510-d306-4688-a3b5-b6ef11dbfbe5)


