### PR TITLE
Change UIA Name properties so that sibling component properties do not match

### DIFF
--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -23703,7 +23703,7 @@ exports[`SensitiveInfo Example Page 1`] = `
                 }
               >
                 <TextInput
-                  accessibilityLabel="Input"
+                  accessibilityLabel="Enter text to set item"
                   onChangeText={[Function]}
                   style={
                     {
@@ -23810,7 +23810,7 @@ exports[`SensitiveInfo Example Page 1`] = `
                 }
               >
                 <TextInput
-                  accessibilityLabel="Input"
+                  accessibilityLabel="Enter text to get item"
                   editable={false}
                   style={
                     {

--- a/src/examples/SensitiveInfoExamplePage.tsx
+++ b/src/examples/SensitiveInfoExamplePage.tsx
@@ -83,7 +83,7 @@ export const SensitiveInfoExamplePage: React.FunctionComponent<{}> = () => {
         <Text style={{color: colors.text, fontWeight: '500'}}>Key:key1 </Text>
         <View style={{flex: 1, flexDirection: 'row', margin: 10}}>
           <TextInput
-            accessibilityLabel="Input"
+            accessibilityLabel="Enter text to set item"
             style={{
               width: 200,
               height: 36,
@@ -102,7 +102,7 @@ export const SensitiveInfoExamplePage: React.FunctionComponent<{}> = () => {
         </View>
         <View style={{flex: 1, flexDirection: 'row', margin: 10}}>
           <TextInput
-            accessibilityLabel="Input"
+            accessibilityLabel="Enter text to get item"
             style={{
               width: 200,
               height: 36,

--- a/src/examples/TTSExamplePage.tsx
+++ b/src/examples/TTSExamplePage.tsx
@@ -40,7 +40,7 @@ export const TTSExamplePage: React.FunctionComponent<{}> = () => {
           onPress={(evt) => onVoicePress(evt, voice)}
           title={voice.name}
           color={voice.id === selectedVoice?.id ? 'steelblue' : 'red'}
-          accessibilityLabel={voice.language}
+          accessibilityLabel={voice.name + ', ' + voice.language}
         />
       </View>
     );


### PR DESCRIPTION
## Description
Changed UIA Name properties of components with the same parent do not have the same Name property. This was previously causing an accessibility issue. In both example pages, the value was changed to match the button components that the error was being thrown on.

### Why

Resolves #367

### What

Modified accessibilityLabel properties of affected components.
