### PR TITLE
Added accessibilityLabel to focusable elements where Name UIA property was 'null'

### DIFF
--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -11318,6 +11318,7 @@ exports[`Hello Example Page 1`] = `
             >
               <View>
                 <View
+                  accessibilityLabel="Check for biometric device!"
                   accessibilityRole="button"
                   accessibilityState={
                     {
@@ -11576,6 +11577,7 @@ exports[`Hello Example Page 1`] = `
             >
               <View>
                 <View
+                  accessibilityLabel="Request user verification"
                   accessibilityRole="button"
                   accessibilityState={
                     {
@@ -11834,6 +11836,7 @@ exports[`Hello Example Page 1`] = `
             >
               <View>
                 <View
+                  accessibilityLabel="Request user verification"
                   accessibilityRole="button"
                   accessibilityState={
                     {
@@ -29959,6 +29962,7 @@ exports[`TextToSpeech Example Page 1`] = `
                 }
               >
                 <TextInput
+                  accessibilityLabel="Enter text here"
                   onChangeText={[Function]}
                   style={
                     {
@@ -29971,6 +29975,7 @@ exports[`TextToSpeech Example Page 1`] = `
                 />
               </View>
               <View
+                accessibilityLabel="Speak"
                 accessibilityRole="button"
                 accessibilityState={
                   {
@@ -39188,6 +39193,7 @@ exports[`Xaml Example Page 1`] = `
               }
             >
               <XamlControl
+                accessibilityLabel="Simple example ToggleSwitch"
                 type="Windows.UI.Xaml.Controls.ToggleSwitch"
               />
             </View>
@@ -39614,6 +39620,7 @@ exports[`Xaml Example Page 1`] = `
               }
             >
               <XamlControl
+                accessibilityLabel="Simple example ComboBox"
                 text="ComboBox"
                 type="Windows.UI.Xaml.Controls.ComboBox"
               >
@@ -39991,6 +39998,7 @@ exports[`Xaml Example Page 1`] = `
               }
             >
               <XamlControl
+                accessibilityLabel="Simple example TextBox"
                 foreground="blue"
                 type="Windows.UI.Xaml.Controls.TextBox"
               />

--- a/src/examples/TTSExamplePage.tsx
+++ b/src/examples/TTSExamplePage.tsx
@@ -68,12 +68,13 @@ export const TTSExamplePage: React.FunctionComponent<{}> = () => {
       <Example title="Speak" code={exampleJsx}>
         <View style={{marginBottom: 8}}>
           <TextInput
+            accessibilityLabel="Enter text here"
             style={{height: 40, borderColor: 'gray', borderWidth: 1}}
             onChangeText={(value: string) => setText(value)}
             value={text}
           />
         </View>
-        <Button onPress={onSpeak} title="Speak" />
+        <Button accessibilityLabel="Speak" onPress={onSpeak} title="Speak" />
         <Text
           style={{
             fontSize: 14,

--- a/src/examples/TrackPlayerExamplePage.tsx
+++ b/src/examples/TrackPlayerExamplePage.tsx
@@ -145,11 +145,15 @@ const Player = () => {
       <View style={styles.container}>
         <ProgressBar />
         <View style={styles.controls}>
-          <Button title="Play" onPress={onPlay} />
-          <Button title="Pause" onPress={onPause} />
-          <Button title="Stop" onPress={onStop} />
-          <Button title="Next" onPress={onNext} />
-          <Button title="Previous" onPress={onPrevious} />
+          <Button accessibilityLabel="Play" title="Play" onPress={onPlay} />
+          <Button accessibilityLabel="Pause" title="Pause" onPress={onPause} />
+          <Button accessibilityLabel="Stop" title="Stop" onPress={onStop} />
+          <Button accessibilityLabel="Next" title="Next" onPress={onNext} />
+          <Button
+            accessibilityLabel="Previous"
+            title="Previous"
+            onPress={onPrevious}
+          />
         </View>
       </View>
     </>

--- a/src/examples/WindowsHelloExamplePage.tsx
+++ b/src/examples/WindowsHelloExamplePage.tsx
@@ -64,6 +64,7 @@ export const WindowsHelloExamplePage: React.FunctionComponent<{}> = () => {
         code={example1jsx}>
         <View>
           <Button
+            accessibilityLabel="Check for biometric device!"
             title="Check for biometric device!"
             onPress={() => {
               SignIn.getDeviceStatus()
@@ -87,6 +88,7 @@ export const WindowsHelloExamplePage: React.FunctionComponent<{}> = () => {
       <Example title="Biometric scan with default message" code={example2jsx}>
         <View>
           <Button
+            accessibilityLabel="Request user verification"
             title="Request user verification"
             onPress={() => {
               SignIn.requestConsentVerification()
@@ -112,6 +114,7 @@ export const WindowsHelloExamplePage: React.FunctionComponent<{}> = () => {
         code={example3jsx}>
         <View>
           <Button
+            accessibilityLabel="Request user verification"
             title="Request user verification"
             onPress={() => {
               SignIn.requestConsentVerification(

--- a/src/examples/XamlExamplePage.tsx
+++ b/src/examples/XamlExamplePage.tsx
@@ -101,7 +101,7 @@ export const XamlExamplePage: React.FunctionComponent<{}> = () => {
         <Button content={{string: 'XAML Button'}} onClick={() => {}} />
       </Example>
       <Example title="A simple XAML ToggleSwitch." code={example3jsx}>
-        <ToggleSwitch />
+        <ToggleSwitch accessibilityLabel="Simple example ToggleSwitch" />
       </Example>
       <Example title="A simple Hyperlink." code={example4jsx}>
         <TextBlock>
@@ -113,7 +113,7 @@ export const XamlExamplePage: React.FunctionComponent<{}> = () => {
         </TextBlock>
       </Example>
       <Example title="A simple ComboBox." code={example5jsx}>
-        <ComboBox text="ComboBox">
+        <ComboBox accessibilityLabel="Simple example ComboBox" text="ComboBox">
           <ComboBoxItem content={{string: 'ComboBoxItem 1'}} />
           <ComboBoxItem content={{string: 'ComboBoxItem 2'}} />
           <ComboBoxItem content={{string: 'ComboBoxItem 3'}} />
@@ -122,7 +122,10 @@ export const XamlExamplePage: React.FunctionComponent<{}> = () => {
       <Example
         title="A simple TextBox with lightweight styling."
         code={example6jsx}>
-        <TextBox foreground="blue" />
+        <TextBox
+          accessibilityLabel="Simple example TextBox"
+          foreground="blue"
+        />
       </Example>
       <Example title="A simple MenuFlyout." code={example7jsx}>
         <Button


### PR DESCRIPTION
## Description
Added accessibilityLabel to focusable elements where Name UIA property was 'null'

### Why
Resolves (partially) #368. 

Datepicker and ProgressView components were not changed - see linked issue comments for more detail.

### What
Added accessbilityLabel property to affected Components.

Before:
![Screenshot (39)](https://github.com/microsoft/react-native-gallery/assets/30995198/2aef7c78-7ee7-4f7c-865e-c68b127dd0b6)

After (check Name property):
![Screenshot (38)](https://github.com/microsoft/react-native-gallery/assets/30995198/19d0738b-7007-48d6-9cce-6f9584e257ce)
