### PR TITLE
Set focusable to 'false' to mimic disabled property behaviour

### DIFF
--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -19359,7 +19359,7 @@ exports[`Pressable Example Page 1`] = `
                   }
                 }
                 accessible={true}
-                focusable={true}
+                focusable={false}
                 onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}

--- a/src/examples/PressableExamplePage.tsx
+++ b/src/examples/PressableExamplePage.tsx
@@ -103,6 +103,7 @@ export const PressableExamplePage: React.FunctionComponent<{}> = () => {
       </Example>
       <Example title="A disabled Pressable component." code={example2jsx}>
         <Pressable
+          focusable={false}
           accessibilityRole="button"
           accessibilityLabel={'example disabled pressable'}
           style={{


### PR DESCRIPTION
## Description
Set the `focusable` property to `false` on disabled pressable example, to mimic expected 'disabled' property behavior. This is because currently, the disabled property is not working as intended: https://github.com/microsoft/react-native-windows/issues/12457

### Why

Resolves #363 

### What

Added focusable property to pressable component - prevents keyboard from tabbing onto or pressing component, similar to behaviour of disabled button in WinUI 3 Gallery.
