### PR TITLE
Change item render functions to prevent focus being lost

### DIFF
--- a/src/examples/VirtualizedListExamplePage.tsx
+++ b/src/examples/VirtualizedListExamplePage.tsx
@@ -172,7 +172,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{}> = () => {
 
   var DATA: INT[] = [];
   const [selectedIndex, setSelectedIndex] = useState();
-  const [selectedgitIndex2, setSelectedIndex2] = useState();
+  const [selectedIndex2, setSelectedIndex2] = useState();
   const [selectedSupport, setSelectedSupport] = useState('None');
   const [getList, setList] = useState([]);
 

--- a/src/examples/VirtualizedListExamplePage.tsx
+++ b/src/examples/VirtualizedListExamplePage.tsx
@@ -172,7 +172,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{}> = () => {
 
   var DATA: INT[] = [];
   const [selectedIndex, setSelectedIndex] = useState();
-  const [selectedIndex2, setSelectedIndex2] = useState();
+  const [selectedgitIndex2, setSelectedIndex2] = useState();
   const [selectedSupport, setSelectedSupport] = useState('None');
   const [getList, setList] = useState([]);
 
@@ -183,71 +183,6 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{}> = () => {
   });
 
   const getItemCount = (data) => 50;
-
-  const Item = ({title, index}) => (
-    <TouchableHighlight style={styles.item}>
-      <Text style={styles.title}>{title}</Text>
-    </TouchableHighlight>
-  );
-
-  const Item2 = ({title, index}) => (
-    <TouchableHighlight
-      style={index === selectedIndex ? styles.itemSelected : styles.item}
-      activeOpacity={0.6}
-      underlayColor={colors.border}
-      onPress={() => {
-        setSelectedIndex(index);
-      }}>
-      <Text style={styles.title}>{title}</Text>
-    </TouchableHighlight>
-  );
-
-  const Item3 = ({title, index}) => (
-    <TouchableHighlight
-      style={index === selectedIndex2 ? styles.itemSelected : styles.item}
-      activeOpacity={selectedSupport === 'None' ? 1 : 0.6}
-      underlayColor={selectedSupport === 'None' ? '' : colors.border}
-      onPress={() => {
-        onPressSupport({index});
-      }}>
-      <Text style={styles.title}>{title}</Text>
-    </TouchableHighlight>
-  );
-
-  const Item3CheckBox = ({title, index}) => (
-    <TouchableHighlight
-      style={getList.includes(index) ? styles.itemSelected : styles.item}
-      activeOpacity={selectedSupport === 'None' ? 1 : 0.6}
-      underlayColor={selectedSupport === 'None' ? '' : colors.border}
-      onPress={() => {
-        onPressSupport({index});
-      }}
-      accessibilityLabel={title}>
-      <View style={styles.item}>
-        <CheckBox
-          value={getList.includes(index) ? true : false}
-          onValueChange={() => {
-            onPressSupport({index});
-          }}
-        />
-        <Text style={styles.title}>{title}</Text>
-      </View>
-    </TouchableHighlight>
-  );
-
-  const onPressSupport = ({index}) => {
-    if (selectedSupport === 'None') {
-      return;
-    } else if (selectedSupport === 'Single') {
-      setSelectedIndex2(index);
-    } else if (selectedSupport === 'Multiple') {
-      if (getList.includes(index)) {
-        setList(getList.filter((item) => item !== index));
-      } else {
-        setList(getList.concat([index]));
-      }
-    }
-  };
 
   const styles = StyleSheet.create({
     container: {
@@ -281,18 +216,67 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{}> = () => {
   });
 
   const renderItem = ({item}) => {
-    return <Item title={item.title} index={item.index} />;
+    return (
+      <TouchableHighlight style={styles.item}>
+        <Text style={styles.title}>{item.title}</Text>
+      </TouchableHighlight>
+    );
   };
 
   const renderItem2 = ({item}) => {
-    return <Item2 title={item.title} index={item.index} />;
+    return (
+      <TouchableHighlight
+        style={item.index === selectedIndex ? styles.itemSelected : styles.item}
+        activeOpacity={0.6}
+        underlayColor={colors.border}
+        onPress={() => {
+          setSelectedIndex(item.index);
+        }}>
+        <Text style={styles.title}>{item.title}</Text>
+      </TouchableHighlight>
+    );
   };
 
   const renderItem3 = ({item}) => {
     return selectedSupport === 'Multiple' ? (
-      <Item3CheckBox title={item.title} index={item.index} />
+      <TouchableHighlight
+        style={getList.includes(item.index) ? styles.itemSelected : styles.item}
+        activeOpacity={0.6}
+        underlayColor={colors.border}
+        onPress={() => {
+          if (getList.includes(item.index)) {
+            setList(getList.filter((value) => value !== item.index));
+          } else {
+            setList(getList.concat([item.index]));
+          }
+        }}
+        accessibilityLabel={item.title}>
+        <View style={styles.item}>
+          <CheckBox
+            value={getList.includes(item.index) ? true : false}
+            onValueChange={() => {
+              if (getList.includes(item.index)) {
+                setList(getList.filter((value) => value !== item.index));
+              } else {
+                setList(getList.concat([item.index]));
+              }
+            }}
+          />
+          <Text style={styles.title}>{item.title}</Text>
+        </View>
+      </TouchableHighlight>
     ) : (
-      <Item3 title={item.title} index={item.index} />
+      <TouchableHighlight
+        style={
+          item.index === selectedIndex2 ? styles.itemSelected : styles.item
+        }
+        activeOpacity={selectedSupport === 'None' ? 1 : 0.6}
+        underlayColor={selectedSupport === 'None' ? '' : colors.border}
+        onPress={() => {
+          setSelectedIndex2(item.index);
+        }}>
+        <Text style={styles.title}>{item.title}</Text>
+      </TouchableHighlight>
     );
   };
 


### PR DESCRIPTION
## Description
Currently, there is an issue with the virtualized list losing focus when an item in the list is pressed. This fix resolves this issue, as it appeared to be caused by the original 'Item' components being unstable nested components, and the state of those components being lost during re-render on pressing the item. This resulted in the focus being lost on the component. Error cause explained here: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md. Looks like this may also have to do with current eslint config settings.

### Why

Resolves #366

### What

Remove the nested `Item` components, and instead pass the TouchableHighlight component directly to the `renderItem` functions.

## Screenshots

Before:
https://microsoft-my.sharepoint-df.com/:v:/p/yajurgrover/ETCmQTj-MldLuW8jG_IWEtsBNEn0Xl4qRLeBVLXKvTsp3g?e=nM4Oer&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D

After:
https://microsoft-my.sharepoint-df.com/:v:/p/yajurgrover/EcbCq26R5EhFiSWwE5FhHCkBOB_BvMfFU9T42DUn8XfnXA?e=CJhDcM&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D