### PR TITLE
Add clipboard example page

### DIFF
--- a/__tests__/App-test.js
+++ b/__tests__/App-test.js
@@ -14,6 +14,7 @@ import {ScrollViewExamplePage} from '../src/examples/ScrollViewExample';
 import {PopupExamplePage} from '../src/examples/PopupExamplePage';
 import {FlyoutExamplePage} from '../src/examples/FlyoutExamplePage';
 import {CheckBoxExamplePage} from '../src/examples/CheckBoxExamplePage';
+import {ClipboardExamplePage} from '../src/examples/ClipboardExamplePage';
 import {ConfigExamplePage} from '../src/examples/ConfigExamplePage';
 import {DatePickerExamplePage} from '../src/examples/DatePickerExamplePage';
 import {TimePickerExamplePage} from '../src/examples/TimePickerExamplePage';
@@ -50,6 +51,11 @@ test('Button Example Page', () => {
 
 test('CheckBox Example Page', () => {
   const tree = create(<CheckBoxExamplePage />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Clipboard Example Page', () => {
+  const tree = create(<ClipboardExamplePage />).toJSON();
   expect(tree).toMatchSnapshot();
 });
 

--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -2260,6 +2260,914 @@ exports[`CheckBox Example Page 1`] = `
 </View>
 `;
 
+exports[`Clipboard Example Page 1`] = `
+<View
+  style={
+    {
+      "flexDirection": "row",
+      "height": "100%",
+      "width": "100%",
+    }
+  }
+>
+  <View
+    accessibilityLabel="Navigation bar"
+    accessibilityRole="button"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    disabled={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "backgroundColor": {
+          "windowsbrush": [
+            "NavigationViewDefaultPaneBackground",
+          ],
+        },
+        "height": "100%",
+        "paddingBottom": 20,
+        "width": 48,
+      }
+    }
+  >
+    <View>
+      <View
+        accessibilityLabel="Navigation bar hamburger icon"
+        accessibilityRole="button"
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "borderRadius": 3,
+            "height": 34,
+            "justifyContent": "center",
+            "margin": 5,
+            "width": 38,
+          }
+        }
+        tooltip="Expand Menu"
+      >
+        <Text
+          style={
+            {
+              "color": {
+                "windowsbrush": [
+                  "TextControlForeground",
+                ],
+              },
+              "fontFamily": "Segoe MDL2 Assets",
+              "fontSize": 16,
+            }
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      {
+        "alignSelf": "stretch",
+        "flexGrow": 1,
+        "flexShrink": 1,
+        "height": "100%",
+        "paddingLeft": 15,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "marginBottom": 10,
+          "marginTop": 44,
+          "paddingRight": 20,
+        }
+      }
+    >
+      <Text
+        accessibilityRole="header"
+        accessible={true}
+        style={
+          [
+            {
+              "fontSize": 26,
+              "fontWeight": "200",
+            },
+            {
+              "color": "rgb(28, 28, 30)",
+            },
+          ]
+        }
+      >
+        Clipboard
+      </Text>
+      <View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "borderRadius": 3,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "margin": 2,
+                "paddingBottom": 5,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 5,
+              },
+              {
+                "backgroundColor": "rgb(28, 28, 30)",
+              },
+            ]
+          }
+          tooltip="This component is not a part of React Native core. The package for this component must be explicitly added in order to have access to this component in a React Native project."
+        >
+          <Text
+            style={
+              [
+                {
+                  "fontSize": 15,
+                  "fontWeight": "400",
+                  "paddingRight": 4,
+                },
+                {
+                  "color": {
+                    "windowsbrush": [
+                      "SystemColorHighlightTextColor",
+                    ],
+                  },
+                },
+              ]
+            }
+          >
+            Community Module
+          </Text>
+          <XamlControl
+            foreground={
+              {
+                "windowsbrush": [
+                  "SystemColorHighlightTextColor",
+                ],
+              }
+            }
+            symbol={57637}
+            type="Windows.UI.Xaml.Controls.SymbolIcon"
+          />
+        </View>
+      </View>
+    </View>
+    <Text
+      style={
+        [
+          {
+            "paddingRight": 20,
+          },
+          {
+            "color": "rgb(28, 28, 30)",
+          },
+        ]
+      }
+    >
+      Copy and paste to and from the system Clipboard.
+    </Text>
+    <RCTScrollView
+      style={
+        {
+          "paddingRight": 20,
+        }
+      }
+    >
+      <View>
+        <View>
+          <Text
+            accessibilityRole="header"
+            style={
+              {
+                "color": "rgb(28, 28, 30)",
+                "fontSize": 20,
+                "marginBottom": 10,
+                "marginTop": 30,
+              }
+            }
+          >
+            Copy text to the Clipboard.
+          </Text>
+          <View
+            style={
+              {
+                "borderColor": "rgb(216, 216, 216)",
+                "borderRadius": 2,
+                "borderWidth": 1,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "padding": 15,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "gap": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      {
+                        "backgroundColor": {
+                          "windowsbrush": [
+                            "ButtonBackground",
+                          ],
+                        },
+                        "borderBottomWidth": 1.5,
+                        "borderColor": {
+                          "windowsbrush": [
+                            "ButtonBorderBrush",
+                          ],
+                        },
+                        "borderRadius": 3,
+                        "borderWidth": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    style={{}}
+                  >
+                    <View
+                      style={{}}
+                    >
+                      <Text
+                        style={
+                          [
+                            {
+                              "color": {
+                                "windowsbrush": [
+                                  "ButtonForeground",
+                                ],
+                              },
+                              "fontSize": 14,
+                              "fontWeight": "400",
+                              "margin": 8,
+                              "textAlign": "center",
+                            },
+                          ]
+                        }
+                      >
+                        Copy text to the Clipboard
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+                <TextInput
+                  onChangeText={[Function]}
+                  value="This text will be copied to the clipboard"
+                />
+              </View>
+            </View>
+            <View
+              style={
+                {
+                  "borderColor": "rgb(216, 216, 216)",
+                  "borderTopWidth": 1,
+                  "borderWidth": 0,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "backgroundColor": "#E6E6E6",
+                    "flexGrow": 1,
+                    "padding": 5,
+                  }
+                }
+              >
+                <Text
+                  selectable={true}
+                  style={
+                    {
+                      "color": "#000000",
+                      "fontFamily": "Consolas",
+                    }
+                  }
+                >
+                  <Text>
+                    &lt;Button
+  title=
+                  </Text>
+                  <Text
+                    style={
+                      {
+                        "color": "#0000FF",
+                      }
+                    }
+                  >
+                    <Text>
+                      "Copy text to the Clipboard"
+                    </Text>
+                  </Text>
+                  <Text>
+                    
+  onPress={
+                  </Text>
+                  <Text
+                    style={{}}
+                  >
+                    <Text>
+                      () =&gt;
+                    </Text>
+                  </Text>
+                  <Text>
+                     Clipboard.setString(textToCopy)}/&gt;
+                  </Text>
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View>
+          <Text
+            accessibilityRole="header"
+            style={
+              {
+                "color": "rgb(28, 28, 30)",
+                "fontSize": 20,
+                "marginBottom": 10,
+                "marginTop": 30,
+              }
+            }
+          >
+            Paste text from the Clipboard.
+          </Text>
+          <View
+            style={
+              {
+                "borderColor": "rgb(216, 216, 216)",
+                "borderRadius": 2,
+                "borderWidth": 1,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "padding": 15,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "gap": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      {
+                        "backgroundColor": {
+                          "windowsbrush": [
+                            "ButtonBackground",
+                          ],
+                        },
+                        "borderBottomWidth": 1.5,
+                        "borderColor": {
+                          "windowsbrush": [
+                            "ButtonBorderBrush",
+                          ],
+                        },
+                        "borderRadius": 3,
+                        "borderWidth": 1,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    style={{}}
+                  >
+                    <View
+                      style={{}}
+                    >
+                      <Text
+                        style={
+                          [
+                            {
+                              "color": {
+                                "windowsbrush": [
+                                  "ButtonForeground",
+                                ],
+                              },
+                              "fontSize": 14,
+                              "fontWeight": "400",
+                              "margin": 8,
+                              "textAlign": "center",
+                            },
+                          ]
+                        }
+                      >
+                        Paste text from the Clipboard
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+                <Text />
+              </View>
+            </View>
+            <View
+              style={
+                {
+                  "borderColor": "rgb(216, 216, 216)",
+                  "borderTopWidth": 1,
+                  "borderWidth": 0,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "backgroundColor": "#E6E6E6",
+                    "flexGrow": 1,
+                    "padding": 5,
+                  }
+                }
+              >
+                <Text
+                  selectable={true}
+                  style={
+                    {
+                      "color": "#000000",
+                      "fontFamily": "Consolas",
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      {
+                        "color": "#000000",
+                      }
+                    }
+                  >
+                    <Text>
+                      const
+                    </Text>
+                  </Text>
+                  <Text>
+                     getClipboardText = 
+                  </Text>
+                  <Text
+                    style={
+                      {
+                        "color": "#000000",
+                      }
+                    }
+                  >
+                    <Text>
+                      async
+                    </Text>
+                  </Text>
+                  <Text>
+                     () =&gt; {
+  
+                  </Text>
+                  <Text
+                    style={
+                      {
+                        "color": "#000000",
+                      }
+                    }
+                  >
+                    <Text>
+                      const
+                    </Text>
+                  </Text>
+                  <Text>
+                     text = 
+                  </Text>
+                  <Text
+                    style={
+                      {
+                        "color": "#000000",
+                      }
+                    }
+                  >
+                    <Text>
+                      await
+                    </Text>
+                  </Text>
+                  <Text>
+                     Clipboard.getString();
+  setTextFromClipboard(text);
+};
+  
+
+                  </Text>
+                  <Text
+                    style={{}}
+                  >
+                    <Text
+                      style={
+                        {
+                          "color": "#0000FF",
+                        }
+                      }
+                    >
+                      <Text>
+                        &lt;
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#A31515",
+                          }
+                        }
+                      >
+                        <Text>
+                          Button
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+  
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          title
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "Paste text from the Clipboard"
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+  
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          onPress
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          {()
+                        </Text>
+                      </Text>
+                      <Text>
+                         =&gt;
+                      </Text>
+                    </Text>
+                    <Text>
+                       getClipboardText()}/&gt;
+                    </Text>
+                  </Text>
+                  <Text>
+                    
+
+                  </Text>
+                  <Text
+                    style={{}}
+                  >
+                    <Text
+                      style={
+                        {
+                          "color": "#0000FF",
+                        }
+                      }
+                    >
+                      <Text>
+                        &lt;
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#A31515",
+                          }
+                        }
+                      >
+                        <Text>
+                          Text
+                        </Text>
+                      </Text>
+                      <Text>
+                        &gt;
+                      </Text>
+                    </Text>
+                    <Text>
+                      {textFromClipboard}
+                    </Text>
+                    <Text
+                      style={
+                        {
+                          "color": "#0000FF",
+                        }
+                      }
+                    >
+                      <Text>
+                        &lt;/
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#A31515",
+                          }
+                        }
+                      >
+                        <Text>
+                          Text
+                        </Text>
+                      </Text>
+                      <Text>
+                        &gt;
+                      </Text>
+                    </Text>
+                  </Text>
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            {
+              "flexDirection": "column",
+              "marginRight": 90,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "alignItems": "flex-start",
+                  "marginBottom": 10,
+                  "marginRight": 30,
+                  "marginTop": 30,
+                }
+              }
+            >
+              <Text
+                accessibilityRole="header"
+                style={
+                  {
+                    "color": "rgb(28, 28, 30)",
+                    "fontSize": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                View page code on Github
+              </Text>
+              <XamlControl
+                content={
+                  {
+                    "string": "Source Code",
+                  }
+                }
+                navigateUri="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/ClipboardExamplePage.tsx"
+                type="Windows.UI.Xaml.Controls.HyperlinkButton"
+              />
+            </View>
+            <View
+              style={
+                {
+                  "alignItems": "flex-start",
+                  "marginBottom": 10,
+                  "marginRight": 30,
+                  "marginTop": 30,
+                }
+              }
+            >
+              <Text
+                accessibilityRole="header"
+                style={
+                  {
+                    "color": "rgb(28, 28, 30)",
+                    "fontSize": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                Feedback
+              </Text>
+              <XamlControl
+                content={
+                  {
+                    "string": "Send feedback about this page",
+                  }
+                }
+                navigateUri="https://github.com/microsoft/react-native-gallery/issues/new"
+                type="Windows.UI.Xaml.Controls.HyperlinkButton"
+              />
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "alignItems": "flex-start",
+                "marginBottom": 10,
+                "marginRight": 30,
+                "marginTop": 30,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="header"
+              style={
+                {
+                  "color": "rgb(28, 28, 30)",
+                  "fontSize": 20,
+                  "marginBottom": 10,
+                }
+              }
+            >
+              Documentation
+            </Text>
+            <XamlControl
+              content={
+                {
+                  "string": "Clipboard",
+                }
+              }
+              navigateUri="https://github.com/react-native-clipboard/clipboard"
+              type="Windows.UI.Xaml.Controls.HyperlinkButton"
+            />
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+  </View>
+</View>
+`;
+
 exports[`Config Example Page 1`] = `
 <View
   style={

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -7,6 +7,9 @@ jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter');
 jest.mock('react-native-device-info', () =>
   require('react-native-device-info/jest/react-native-device-info-mock'),
 );
+jest.mock('@react-native-clipboard/clipboard', () =>
+  require('@react-native-clipboard/clipboard/jest/clipboard-mock'),
+);
 
 process.env.NODE_ENV = 'test';
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@fluentui-react-native/experimental-expander": "^0.6.1",
-    "@react-native-clipboard/clipboard": "^1.13.2",
+    "@react-native-clipboard/clipboard": "^1.14.0",
     "@react-native-community/checkbox": "^0.5.16",
     "@react-native-community/datetimepicker": "^7.6.0",
     "@react-native-community/masked-view": "^0.1.11",

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -2,7 +2,7 @@
 import {StyleSheet, View, Text, Pressable} from 'react-native';
 import React from 'react';
 import {useTheme, useIsFocused} from '@react-navigation/native';
-import RNGalleryList from './RNGalleryList';
+import RNGalleryList, {RNGalleryCategories} from './RNGalleryList';
 import {ScrollView} from 'react-native';
 import {ScreenWrapper} from './components/ScreenWrapper';
 
@@ -122,53 +122,24 @@ const RenderHomeComponentTiles = (indicies: number[], navigation) => {
 };
 
 const RenderPageContent = ({navigation}) => {
-  var basicInput = [];
-  var dateAndTime = [];
-  var dialogsAndFlyouts = [];
-  var layout = [];
-  var text = [];
-  var statusAndInfo = [];
-  var media = [];
-  for (var i = 0; i < RNGalleryList.length; i++) {
-    if (RNGalleryList[i].type === 'Basic Input') {
-      basicInput.push(i);
-    } else if (RNGalleryList[i].type === 'Date and Time') {
-      dateAndTime.push(i);
-    } else if (RNGalleryList[i].type === 'Dialogs and Flyouts') {
-      dialogsAndFlyouts.push(i);
-    } else if (RNGalleryList[i].type === 'Layout') {
-      layout.push(i);
-    } else if (RNGalleryList[i].type === 'Text') {
-      text.push(i);
-    } else if (RNGalleryList[i].type === 'Status and Info') {
-      statusAndInfo.push(i);
-    } else if (RNGalleryList[i].type === 'Media') {
-      media.push(i);
-    }
-  }
+  let categoryMap = new Map();
+  RNGalleryCategories.forEach((category) => {
+    categoryMap.set(category, []);
+  });
+
+  RNGalleryList.forEach((item, index) => {
+    let category = item.type;
+    let categoryList = categoryMap.get(category);
+    categoryList?.push(index);
+  });
+
   return (
     <ScrollView>
-      <HomeContainer heading="Basic Input">
-        {RenderHomeComponentTiles(basicInput, navigation)}
-      </HomeContainer>
-      <HomeContainer heading="Date and Time">
-        {RenderHomeComponentTiles(dateAndTime, navigation)}
-      </HomeContainer>
-      <HomeContainer heading="Dialogs and Flyouts">
-        {RenderHomeComponentTiles(dialogsAndFlyouts, navigation)}
-      </HomeContainer>
-      <HomeContainer heading="Layout">
-        {RenderHomeComponentTiles(layout, navigation)}
-      </HomeContainer>
-      <HomeContainer heading="Text">
-        {RenderHomeComponentTiles(text, navigation)}
-      </HomeContainer>
-      <HomeContainer heading="Status and Info">
-        {RenderHomeComponentTiles(statusAndInfo, navigation)}
-      </HomeContainer>
-      <HomeContainer heading="Media">
-        {RenderHomeComponentTiles(media, navigation)}
-      </HomeContainer>
+      {RNGalleryCategories.map((category) => (
+        <HomeContainer key={category} heading={category}>
+          {RenderHomeComponentTiles(categoryMap.get(category), navigation)}
+        </HomeContainer>
+      ))}
     </ScrollView>
   );
 };

--- a/src/RNGalleryList.ts
+++ b/src/RNGalleryList.ts
@@ -44,6 +44,7 @@ let RNGalleryCategories = [
   'Layout',
   'Status and Info',
   'Media',
+  'Text',
   'System',
 ];
 

--- a/src/RNGalleryList.ts
+++ b/src/RNGalleryList.ts
@@ -4,6 +4,7 @@ import {HomePage} from './HomePage';
 import {SettingsPage} from './SettingsPage';
 import {ButtonExamplePage} from './examples/ButtonExamplePage';
 import {CheckBoxExamplePage} from './examples/CheckBoxExamplePage';
+import {ClipboardExamplePage} from './examples/ClipboardExamplePage';
 import {ConfigExamplePage} from './examples/ConfigExamplePage';
 import {DatePickerExamplePage} from './examples/DatePickerExamplePage';
 import {TimePickerExamplePage} from './examples/TimePickerExamplePage';
@@ -36,6 +37,16 @@ import {WindowsHelloExamplePage} from './examples/WindowsHelloExamplePage';
 import {ExpanderExamplePage} from './examples/ExpanderExamplePage';
 import {VirtualizedListExamplePage} from './examples/VirtualizedListExamplePage';
 
+let RNGalleryCategories = [
+  'Basic Input',
+  'Date and Time',
+  'Dialogs and Flyouts',
+  'Layout',
+  'Status and Info',
+  'Media',
+  'System',
+];
+
 interface IRNGalleryExample {
   key: string;
   component: React.ElementType;
@@ -67,6 +78,12 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     component: CheckBoxExamplePage,
     icon: '\uE73A',
     type: 'Basic Input',
+  },
+  {
+    key: 'Clipboard',
+    component: ClipboardExamplePage,
+    icon: '\uE8C8',
+    type: 'System',
   },
   {
     key: 'Config',
@@ -257,3 +274,4 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
 ];
 
 export default RNGalleryList;
+export {RNGalleryCategories};

--- a/src/examples/ClipboardExamplePage.tsx
+++ b/src/examples/ClipboardExamplePage.tsx
@@ -1,0 +1,64 @@
+'use strict';
+import React, {useState} from 'react';
+import {Button, Text, TextInput, View} from 'react-native';
+import {Example} from '../components/Example';
+import {Page} from '../components/Page';
+import Clipboard from '@react-native-clipboard/clipboard';
+
+export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
+  const [textToCopy, setTextToCopy] = useState(
+    'This text will be copied to the clipboard',
+  );
+  const [textFromClipboard, setTextFromClipboard] = useState('');
+  const example1jsx = `<Button
+  title="Copy text to the Clipboard"
+  onPress={() => Clipboard.setString(textToCopy)}/>`;
+  const example2jsx = `const getClipboardText = async () => {
+  const text = await Clipboard.getString();
+  setTextFromClipboard(text);
+};
+  
+<Button
+  title="Paste text from the Clipboard"
+  onPress={() => getClipboardText()}/>
+<Text>{textFromClipboard}</Text>`;
+
+  const getClipboardText = async () => {
+    const text = await Clipboard.getString();
+    setTextFromClipboard(text);
+  };
+
+  return (
+    <Page
+      title="Clipboard"
+      description="Copy and paste to and from the system Clipboard."
+      componentType="Community"
+      pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/ClipboardExamplePage.tsx"
+      documentation={[
+        {
+          label: 'Clipboard',
+          url: 'https://github.com/react-native-clipboard/clipboard',
+        },
+      ]}>
+      <Example title="Copy text to the Clipboard." code={example1jsx}>
+        <View style={{alignItems: 'flex-start', gap: 12}}>
+          <Button
+            title="Copy text to the Clipboard"
+            onPress={() => Clipboard.setString(textToCopy)}
+          />
+          <TextInput value={textToCopy} onChangeText={setTextToCopy} />
+        </View>
+      </Example>
+
+      <Example title="Paste text from the Clipboard." code={example2jsx}>
+        <View style={{alignItems: 'flex-start', gap: 12}}>
+          <Button
+            title="Paste text from the Clipboard"
+            onPress={() => getClipboardText()}
+          />
+          <Text>{textFromClipboard}</Text>
+        </View>
+      </Example>
+    </Page>
+  );
+};


### PR DESCRIPTION
## Description

### Why

Clipboard is a module already included by Gallery, but doesn't have a sample page. Furthermore, the WinUI gallery has a sample page for clipboard.

### What

Adds a sample page for Clipboard, which behaves identically to the one in WinUI gallery.

## Screenshots

![image](https://github.com/microsoft/react-native-gallery/assets/26607885/dc1b2234-a9cf-41f0-b96c-75c5cc8c9463)

