### PR TITLE
Add linear gradient example page

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-native-config": "luggit/react-native-config",
     "react-native-device-info": "^10.7.0",
     "react-native-gesture-handler": "2.9.0",
+    "react-native-linear-gradient": "3.0.0-alpha.1",
     "react-native-permissions": "^3.8.1",
     "react-native-print": "0.8.0",
     "react-native-reanimated": "^1.10.0",

--- a/patches/react-native-linear-gradient+3.0.0-alpha.1.patch
+++ b/patches/react-native-linear-gradient+3.0.0-alpha.1.patch
@@ -1,0 +1,24 @@
+diff --git a/node_modules/react-native-linear-gradient/windows/RNLinearGradient/RNLinearGradient/RNLinearGradient.vcxproj b/node_modules/react-native-linear-gradient/windows/RNLinearGradient/RNLinearGradient/RNLinearGradient.vcxproj
+index 5e228da..7870388 100644
+--- a/node_modules/react-native-linear-gradient/windows/RNLinearGradient/RNLinearGradient/RNLinearGradient.vcxproj
++++ b/node_modules/react-native-linear-gradient/windows/RNLinearGradient/RNLinearGradient/RNLinearGradient.vcxproj
+@@ -13,13 +13,16 @@
+     <AppContainerApplication>true</AppContainerApplication>
+     <ApplicationType>Windows Store</ApplicationType>
+     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
+-    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
+   </PropertyGroup>
+-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup Label="ReactNativeWindowsProps">
+     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
+   </PropertyGroup>
++  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props')" />
++  <PropertyGroup Label="Fallback Windows SDK Versions">
++   <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
++   <WindowsTargetPlatformMinVersion Condition=" '$(WindowsTargetPlatformMinVersion)' == '' ">10.0.16299.0</WindowsTargetPlatformMinVersion>
++  </PropertyGroup>
++  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <ItemGroup Label="ProjectConfigurations">
+     <ProjectConfiguration Include="Debug|ARM">
+       <Configuration>Debug</Configuration>

--- a/src/RNGalleryList.ts
+++ b/src/RNGalleryList.ts
@@ -35,6 +35,7 @@ import {TrackPlayerExamplePage} from './examples/TrackPlayerExamplePage';
 import {WindowsHelloExamplePage} from './examples/WindowsHelloExamplePage';
 import {ExpanderExamplePage} from './examples/ExpanderExamplePage';
 import {VirtualizedListExamplePage} from './examples/VirtualizedListExamplePage';
+import {LinearGradientExamplePage} from './examples/LinearGradientExamplePage';
 
 interface IRNGalleryExample {
   key: string;
@@ -108,6 +109,12 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     key: 'Image',
     component: ImageExamplePage,
     icon: '\uEB9F',
+    type: 'Media',
+  },
+  {
+    key: 'Linear Gradient',
+    component: LinearGradientExamplePage,
+    icon: '\uE790',
     type: 'Media',
   },
   {

--- a/src/examples/LinearGradientExamplePage.tsx
+++ b/src/examples/LinearGradientExamplePage.tsx
@@ -1,0 +1,50 @@
+'use strict';
+import React from 'react';
+import {Text} from 'react-native';
+import {Example} from '../components/Example';
+import {Page} from '../components/Page';
+import LinearGradient from 'react-native-linear-gradient';
+
+export const LinearGradientExamplePage: React.FunctionComponent<{}> = () => {
+  const example1jsx = `<LinearGradient
+  start={{x: 0, y: 0}}
+  end={{x: 1, y: 0}}
+  colors={['#4c669f', '#3b5998', '#192f6a']}
+  style={{
+    paddingHorizontal: 24,
+    paddingVertical: 8,
+    borderRadius: 8,
+    alignSelf: 'flex-start'}}>
+  <Text>
+    Text within a gradient fill
+  </Text>
+</LinearGradient>`;
+  return (
+    <Page
+      title="Linear Gradient"
+      description="Render a gradient color fill."
+      componentType="Community"
+      pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/LinearGradientExamplePage.tsx"
+      documentation={[
+        {
+          label: 'Linear Gradient',
+          url: 'https://github.com/react-native-linear-gradient/react-native-linear-gradient',
+        },
+      ]}>
+      <Example title="Horizontal Gradient" code={example1jsx}>
+        <LinearGradient
+          start={{x: 0, y: 0}}
+          end={{x: 1, y: 0}}
+          colors={['#4c669f', '#3b5998', '#192f6a']}
+          style={{
+            paddingHorizontal: 24,
+            paddingVertical: 8,
+            borderRadius: 8,
+            alignSelf: 'flex-start',
+          }}>
+          <Text style={{color: '#ffffff'}}>Text within a gradient fill</Text>
+        </LinearGradient>
+      </Example>
+    </Page>
+  );
+};

--- a/windows/rngallery.sln
+++ b/windows/rngallery.sln
@@ -69,6 +69,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactNativeXaml", "..\node_
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactNativeWindowsHello", "..\node_modules\react-native-windows-hello\windows\ReactNativeWindowsHello\ReactNativeWindowsHello.vcxproj", "{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RNLinearGradient", "..\node_modules\react-native-linear-gradient\windows\RNLinearGradient\RNLinearGradient\RNLinearGradient.vcxproj", "{193DF456-3F97-4CC1-A7D4-809857CC064E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -375,6 +377,18 @@ Global
 		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Release|x64.Build.0 = Release|x64
 		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Release|x86.ActiveCfg = Release|Win32
 		{82BF2B2C-EDA5-47CA-A9F5-56BA622A15EA}.Release|x86.Build.0 = Release|Win32
+		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Debug|ARM64.Build.0 = Debug|ARM64
+		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Debug|x64.ActiveCfg = Debug|x64
+		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Debug|x64.Build.0 = Debug|x64
+		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Debug|x86.ActiveCfg = Debug|Win32
+		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Debug|x86.Build.0 = Debug|Win32
+		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Release|ARM64.ActiveCfg = Release|ARM64
+		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Release|ARM64.Build.0 = Release|ARM64
+		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Release|x64.ActiveCfg = Release|x64
+		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Release|x64.Build.0 = Release|x64
+		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Release|x86.ActiveCfg = Release|Win32
+		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/windows/rngallery/AutolinkedNativeModules.g.cpp
+++ b/windows/rngallery/AutolinkedNativeModules.g.cpp
@@ -33,6 +33,9 @@
 // Includes from react-native-device-info
 #include <winrt/RNDeviceInfoCPP.h>
 
+// Includes from react-native-linear-gradient
+#include <winrt/RNLinearGradient.h>
+
 // Includes from react-native-permissions
 #include <winrt/RNPermissions.h>
 
@@ -82,6 +85,8 @@ void RegisterAutolinkedNativeModulePackages(winrt::Windows::Foundation::Collecti
     packageProviders.Append(winrt::RNCConfig::ReactPackageProvider());
     // IReactPackageProviders from react-native-device-info
     packageProviders.Append(winrt::RNDeviceInfoCPP::ReactPackageProvider());
+    // IReactPackageProviders from react-native-linear-gradient
+    packageProviders.Append(winrt::RNLinearGradient::ReactPackageProvider());
     // IReactPackageProviders from react-native-permissions
     packageProviders.Append(winrt::RNPermissions::ReactPackageProvider());
     // IReactPackageProviders from react-native-print

--- a/windows/rngallery/AutolinkedNativeModules.g.targets
+++ b/windows/rngallery/AutolinkedNativeModules.g.targets
@@ -42,6 +42,10 @@
     <ProjectReference Include="$(ProjectDir)..\..\node_modules\react-native-device-info\windows\RNDeviceInfoCPP\RNDeviceInfoCPP.vcxproj">
       <Project>{3e3931f2-4735-4417-8cb0-33668a7314d6}</Project>
     </ProjectReference>
+    <!-- Projects from react-native-linear-gradient -->
+    <ProjectReference Include="$(ProjectDir)..\..\node_modules\react-native-linear-gradient\windows\RNLinearGradient\RNLinearGradient\RNLinearGradient.vcxproj">
+      <Project>{193df456-3f97-4cc1-a7d4-809857cc064e}</Project>
+    </ProjectReference>
     <!-- Projects from react-native-permissions -->
     <ProjectReference Include="$(ProjectDir)..\..\node_modules\react-native-permissions\windows\RNPermissions\RNPermissions.vcxproj">
       <Project>{99677b9d-a27b-4239-930e-c36c8d339c54}</Project>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9853,6 +9853,11 @@ react-native-gesture-handler@2.9.0:
     lodash "^4.17.21"
     prop-types "^15.7.2"
 
+react-native-linear-gradient@3.0.0-alpha.1:
+  version "3.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-3.0.0-alpha.1.tgz#fa1914462536f052faa211c34240be3ab1856bdd"
+  integrity sha512-vo9ks7m2VTLtbdAIMqwk944SB65+rc0U1a2R1CAQetT282DnH4rI3GKenaa+Gj2gPngF1l7Mc3Jxk9+6IZDraA==
+
 react-native-permissions@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.8.1.tgz#8d38578686e77caf6e7faf7568411da98ab12d89"


### PR DESCRIPTION
## Description

### Why

Module supports Windows and is being used for some visual rejuvenation of the gallery app's home page.

### What

Adds a dependency on react-native-linear-gradient and adds a sample page.

## Screenshots

![image](https://github.com/microsoft/react-native-gallery/assets/26607885/977755ee-0860-4f64-aca2-49cb2e0d302c)
