### PR TITLE
Add radio buttons example

### DIFF
--- a/__tests__/App-test.js
+++ b/__tests__/App-test.js
@@ -34,6 +34,7 @@ import {XamlExamplePage} from '../src/examples/XamlExamplePage';
 //import {TrackPlayerExamplePage} from '../src/examples/TrackPlayerExamplePage';
 import {WindowsHelloExamplePage} from '../src/examples/WindowsHelloExamplePage';
 import {ExpanderExamplePage} from '../src/examples/ExpanderExamplePage';
+// https://github.com/microsoft/react-native-gallery/issues/420
 // Unable to import: {export * from './types'; SyntaxError: Unexpected token 'export'
 //import {RadioButtonsExamplePage} from '../src/examples/RadioButtonsExamplePage';
 import {View} from 'react-native';

--- a/__tests__/App-test.js
+++ b/__tests__/App-test.js
@@ -34,6 +34,8 @@ import {XamlExamplePage} from '../src/examples/XamlExamplePage';
 //import {TrackPlayerExamplePage} from '../src/examples/TrackPlayerExamplePage';
 import {WindowsHelloExamplePage} from '../src/examples/WindowsHelloExamplePage';
 import {ExpanderExamplePage} from '../src/examples/ExpanderExamplePage';
+// Unable to import: {export * from './types'; SyntaxError: Unexpected token 'export'
+//import {RadioButtonsExamplePage} from '../src/examples/RadioButtonsExamplePage';
 import {View} from 'react-native';
 
 function Control() {
@@ -136,6 +138,11 @@ test('ProgressView Example Page', () => {
   const tree = create(<ProgressViewExamplePage />).toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+/*test('Radio Buttons Example Page', () => {
+  const tree = create(<RadioButtonsExamplePage />).toJSON();
+  expect(tree).toMatchSnapshot();
+});*/
 
 test('ScrollView Example Page', () => {
   const tree = create(<ScrollViewExamplePage />).toJSON();

--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -50177,7 +50177,7 @@ exports[`Xaml Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -50185,6 +50185,11 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -50227,16 +50232,22 @@ You selected Option 1
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -50744,6 +50755,85 @@ You selected Option 1
                     </Text>
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>

--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -8156,7 +8156,7 @@ exports[`Expander Example Page 1`] = `
                       undefined,
                     ]
                   }
-                  timeZoneOffsetInSeconds={-0}
+                  timeZoneOffsetInSeconds={-28800}
                 />
               </ExpanderView>
             </View>
@@ -50155,6 +50155,595 @@ exports[`Xaml Example Page 1`] = `
                     
                   </Text>
                 </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View>
+          <Text
+            accessibilityRole="header"
+            style={
+              {
+                "color": "rgb(28, 28, 30)",
+                "fontSize": 20,
+                "marginBottom": 10,
+                "marginTop": 30,
+              }
+            }
+          >
+            A simple XAML radio group.
+          </Text>
+          <View
+            style={
+              {
+                "borderColor": "rgb(216, 216, 216)",
+                "borderRadius": 2,
+                "borderWidth": 1,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "padding": 15,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <View>
+                  <XamlControl
+                    content="Option 1"
+                    isChecked={true}
+                    onChecked={[Function]}
+                    tag="1"
+                    type="Windows.UI.Xaml.Controls.RadioButton"
+                  />
+                  <XamlControl
+                    content="Option 2"
+                    onChecked={[Function]}
+                    tag="2"
+                    type="Windows.UI.Xaml.Controls.RadioButton"
+                  />
+                  <XamlControl
+                    content="Option 3"
+                    onChecked={[Function]}
+                    tag="3"
+                    type="Windows.UI.Xaml.Controls.RadioButton"
+                  />
+                </View>
+                <Text>
+                  Output:
+You selected Option 1
+                </Text>
+              </View>
+            </View>
+            <View
+              style={
+                {
+                  "borderColor": "rgb(216, 216, 216)",
+                  "borderTopWidth": 1,
+                  "borderWidth": 0,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "backgroundColor": "#E6E6E6",
+                    "flexGrow": 1,
+                    "padding": 5,
+                  }
+                }
+              >
+                <Text
+                  selectable={true}
+                  style={
+                    {
+                      "color": "#000000",
+                      "fontFamily": "Consolas",
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      {
+                        "color": "#000000",
+                      }
+                    }
+                  >
+                    <Text>
+                      const
+                    </Text>
+                  </Text>
+                  <Text>
+                     [selectedRadioButton, setSelectedRadioButton] = useState(
+                  </Text>
+                  <Text
+                    style={
+                      {
+                        "color": "#0000FF",
+                      }
+                    }
+                  >
+                    <Text>
+                      '1'
+                    </Text>
+                  </Text>
+                  <Text>
+                    );
+
+                  </Text>
+                  <Text
+                    style={
+                      {
+                        "color": "#000000",
+                      }
+                    }
+                  >
+                    <Text>
+                      const
+                    </Text>
+                  </Text>
+                  <Text>
+                     onRadioButtonSelected = 
+                  </Text>
+                  <Text
+                    style={{}}
+                  >
+                    <Text>
+                      (
+                    </Text>
+                    <Text
+                      style={{}}
+                    >
+                      <Text>
+                        event
+                      </Text>
+                    </Text>
+                    <Text>
+                      ) =&gt;
+                    </Text>
+                  </Text>
+                  <Text>
+                     {
+  setSelectedRadioButton(event.nativeEvent?.sender.tag);
+};
+
+
+                  </Text>
+                  <Text
+                    style={{}}
+                  >
+                    <Text
+                      style={
+                        {
+                          "color": "#0000FF",
+                        }
+                      }
+                    >
+                      <Text>
+                        &lt;
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#A31515",
+                          }
+                        }
+                      >
+                        <Text>
+                          View
+                        </Text>
+                      </Text>
+                      <Text>
+                        &gt;
+                      </Text>
+                    </Text>
+                    <Text>
+                      
+  
+                    </Text>
+                    <Text
+                      style={
+                        {
+                          "color": "#0000FF",
+                        }
+                      }
+                    >
+                      <Text>
+                        &lt;
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#A31515",
+                          }
+                        }
+                      >
+                        <Text>
+                          RadioButton
+                        </Text>
+                      </Text>
+                      <Text>
+                         
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          content
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "Option 1"
+                        </Text>
+                      </Text>
+                      <Text>
+                         
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          tag
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "1"
+                        </Text>
+                      </Text>
+                      <Text>
+                         
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          isChecked
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          {true}
+                        </Text>
+                      </Text>
+                      <Text>
+                         
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          onChecked
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          {onRadioButtonSelected}/
+                        </Text>
+                      </Text>
+                      <Text>
+                        &gt;
+                      </Text>
+                    </Text>
+                    <Text>
+                      
+  
+                    </Text>
+                    <Text
+                      style={
+                        {
+                          "color": "#0000FF",
+                        }
+                      }
+                    >
+                      <Text>
+                        &lt;
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#A31515",
+                          }
+                        }
+                      >
+                        <Text>
+                          RadioButton
+                        </Text>
+                      </Text>
+                      <Text>
+                         
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          content
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "Option 2"
+                        </Text>
+                      </Text>
+                      <Text>
+                         
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          tag
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "2"
+                        </Text>
+                      </Text>
+                      <Text>
+                         
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          onChecked
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          {onRadioButtonSelected}/
+                        </Text>
+                      </Text>
+                      <Text>
+                        &gt;
+                      </Text>
+                    </Text>
+                    <Text>
+                      
+  
+                    </Text>
+                    <Text
+                      style={
+                        {
+                          "color": "#0000FF",
+                        }
+                      }
+                    >
+                      <Text>
+                        &lt;
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#A31515",
+                          }
+                        }
+                      >
+                        <Text>
+                          RadioButton
+                        </Text>
+                      </Text>
+                      <Text>
+                         
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          content
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "Option 3"
+                        </Text>
+                      </Text>
+                      <Text>
+                         
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          tag
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "3"
+                        </Text>
+                      </Text>
+                      <Text>
+                         
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          onChecked
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          {onRadioButtonSelected}/
+                        </Text>
+                      </Text>
+                      <Text>
+                        &gt;
+                      </Text>
+                    </Text>
+                    <Text>
+                      
+
+                    </Text>
+                    <Text
+                      style={
+                        {
+                          "color": "#0000FF",
+                        }
+                      }
+                    >
+                      <Text>
+                        &lt;/
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#A31515",
+                          }
+                        }
+                      >
+                        <Text>
+                          View
+                        </Text>
+                      </Text>
+                      <Text>
+                        &gt;
+                      </Text>
+                    </Text>
+                  </Text>
+                </Text>
               </View>
             </View>
           </View>

--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -8156,7 +8156,7 @@ exports[`Expander Example Page 1`] = `
                       undefined,
                     ]
                   }
-                  timeZoneOffsetInSeconds={-28800}
+                  timeZoneOffsetInSeconds={-0}
                 />
               </ExpanderView>
             </View>

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-native-linear-gradient": "3.0.0-alpha.1",
     "react-native-permissions": "^3.8.1",
     "react-native-print": "0.8.0",
+    "react-native-radio-buttons-group": "^3.1.0",
     "react-native-reanimated": "^1.10.0",
     "react-native-safe-area-context": "^4.2.4",
     "react-native-screens": "^2.9.0",

--- a/src/RNGalleryList.ts
+++ b/src/RNGalleryList.ts
@@ -203,7 +203,10 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
   {
     key: 'Radio Buttons',
     component: RadioButtonsExamplePage,
-    icon: '\uECCB',
+    textIcon: '\uECCB',
+    imageIcon: require('../assets/ControlImages/RadioButtons.png'),
+    subtitle:
+      'A control that allows the user to select a single option from a group of options.',
     type: 'Basic Input',
   },
   {

--- a/src/RNGalleryList.ts
+++ b/src/RNGalleryList.ts
@@ -32,6 +32,7 @@ import {SensitiveInfoExamplePage} from './examples/SensitiveInfoExamplePage';
 import {PopupExamplePage} from './examples/PopupExamplePage';
 import {FlyoutExamplePage} from './examples/FlyoutExamplePage';
 import {ProgressViewExamplePage} from './examples/ProgressViewExamplePage';
+import {RadioButtonsExamplePage} from './examples/RadioButtonsExamplePage';
 import {XamlExamplePage} from './examples/XamlExamplePage';
 import {TrackPlayerExamplePage} from './examples/TrackPlayerExamplePage';
 import {WindowsHelloExamplePage} from './examples/WindowsHelloExamplePage';
@@ -197,6 +198,12 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     imageIcon: require('../assets/ControlImages/ProgressBar.png'),
     subtitle:
       "Shows the apps progress on a task, or that the app is performing ongoing work that doesn't block user interaction.",
+    type: 'Basic Input',
+  },
+  {
+    key: 'Radio Buttons',
+    component: RadioButtonsExamplePage,
+    icon: '\uECCB',
     type: 'Basic Input',
   },
   {

--- a/src/examples/RadioButtonsExamplePage.tsx
+++ b/src/examples/RadioButtonsExamplePage.tsx
@@ -1,0 +1,72 @@
+'use strict';
+import React, {useState} from 'react';
+import {Text, View} from 'react-native';
+import {Example} from '../components/Example';
+import {Page} from '../components/Page';
+import RadioGroup from 'react-native-radio-buttons-group';
+
+export const RadioButtonsExamplePage: React.FunctionComponent<{}> = () => {
+  const [radioSelection, setRadioSelection] = useState('3');
+  const example1jsx = `<RadioGroup
+  onPress={setRadioSelection}
+  selectedId={radioSelection}
+  radioButtons={[
+    {
+      id: '1',
+      label: 'Option 1',
+      value: 'option1'
+    },
+    {
+        id: '2',
+        label: 'Option 2',
+        value: 'option2'
+    },
+    {
+        id: '3',
+        label: 'Option 3',
+        value: 'option3'
+    }
+  ]}/>`;
+  return (
+    <Page
+      title="Radio Buttons"
+      description="Use radio buttons to let a user choose between mutually exclusive, related options."
+      componentType="Community"
+      pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/LinearGradientExamplePage.tsx"
+      documentation={[
+        {
+          label: 'Radio Buttons Group',
+          url: 'https://github.com/thakurballary/react-native-radio-buttons-group',
+        },
+      ]}>
+      <Example title="A Radio Group" code={example1jsx}>
+        <Text>Options:</Text>
+        <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
+          <RadioGroup
+            onPress={setRadioSelection}
+            selectedId={radioSelection}
+            radioButtons={[
+              {
+                id: '1',
+                label: 'Option 1',
+                value: 'option1',
+              },
+              {
+                id: '2',
+                label: 'Option 2',
+                value: 'option2',
+              },
+              {
+                id: '3',
+                label: 'Option 3',
+                value: 'option3',
+              },
+            ]}
+          />
+          <Text>{`Output:
+You selected Option ${radioSelection}`}</Text>
+        </View>
+      </Example>
+    </Page>
+  );
+};

--- a/src/examples/XamlExamplePage.tsx
+++ b/src/examples/XamlExamplePage.tsx
@@ -27,8 +27,8 @@ export const XamlExamplePage: React.FunctionComponent<{}> = () => {
   );
   const [selectedRadioButton, setSelectedRadioButton] = useState('1');
   const onRadioButtonSelected = (event) => {
-    setSelectedRadioButton(event.nativeEvent?.sender.tag)
-  }
+    setSelectedRadioButton(event.nativeEvent?.sender.tag);
+  };
 
   const example1jsx = '<TextBlock text="I am a XAML TextBlock." />';
   const example2jsx =
@@ -82,11 +82,10 @@ export const XamlExamplePage: React.FunctionComponent<{}> = () => {
     <FontIcon glyph="&#xE790;" />
   </NavigationViewItem>
 </NavigationView>`;
-const example9jsx = `
-const [selectedRadioButton, setSelectedRadioButton] = useState('1');
+  const example9jsx = `const [selectedRadioButton, setSelectedRadioButton] = useState('1');
 const onRadioButtonSelected = (event) => {
-  setSelectedRadioButton(event.nativeEvent?.sender.tag)
-}
+  setSelectedRadioButton(event.nativeEvent?.sender.tag);
+};
 
 <View>
   <RadioButton content="Option 1" tag="1" isChecked={true} onChecked={onRadioButtonSelected}/>
@@ -131,9 +130,22 @@ const onRadioButtonSelected = (event) => {
       <Example title="A simple XAML radio group." code={example9jsx}>
         <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
           <View>
-            <RadioButton content="Option 1" tag="1" isChecked={true} onChecked={onRadioButtonSelected}/>
-            <RadioButton content="Option 2" tag="2" onChecked={onRadioButtonSelected}/>
-            <RadioButton content="Option 3" tag="3" onChecked={onRadioButtonSelected}/>
+            <RadioButton
+              content="Option 1"
+              tag="1"
+              isChecked={true}
+              onChecked={onRadioButtonSelected}
+            />
+            <RadioButton
+              content="Option 2"
+              tag="2"
+              onChecked={onRadioButtonSelected}
+            />
+            <RadioButton
+              content="Option 3"
+              tag="3"
+              onChecked={onRadioButtonSelected}
+            />
           </View>
           <Text>{`Output:
 You selected Option ${selectedRadioButton}`}</Text>

--- a/src/examples/XamlExamplePage.tsx
+++ b/src/examples/XamlExamplePage.tsx
@@ -1,5 +1,5 @@
 'use strict';
-import {View} from 'react-native';
+import {Text, View} from 'react-native';
 import React, {useState} from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
@@ -7,6 +7,7 @@ import {
   TextBlock,
   Button,
   Hyperlink,
+  RadioButton,
   Run,
   ToggleSwitch,
   ComboBox,
@@ -24,6 +25,10 @@ export const XamlExamplePage: React.FunctionComponent<{}> = () => {
   const [menuFlyoutOption, setMenuFlyoutOption] = useState(
     'MenuFlyout Option 1',
   );
+  const [selectedRadioButton, setSelectedRadioButton] = useState('1');
+  const onRadioButtonSelected = (event) => {
+    setSelectedRadioButton(event.nativeEvent?.sender.tag)
+  }
 
   const example1jsx = '<TextBlock text="I am a XAML TextBlock." />';
   const example2jsx =
@@ -77,6 +82,17 @@ export const XamlExamplePage: React.FunctionComponent<{}> = () => {
     <FontIcon glyph="&#xE790;" />
   </NavigationViewItem>
 </NavigationView>`;
+const example9jsx = `
+const [selectedRadioButton, setSelectedRadioButton] = useState('1');
+const onRadioButtonSelected = (event) => {
+  setSelectedRadioButton(event.nativeEvent?.sender.tag)
+}
+
+<View>
+  <RadioButton content="Option 1" tag="1" isChecked={true} onChecked={onRadioButtonSelected}/>
+  <RadioButton content="Option 2" tag="2" onChecked={onRadioButtonSelected}/>
+  <RadioButton content="Option 3" tag="3" onChecked={onRadioButtonSelected}/>
+</View>`;
 
   return (
     <Page
@@ -111,6 +127,17 @@ export const XamlExamplePage: React.FunctionComponent<{}> = () => {
           </Hyperlink>
           <Run text=" repository." />
         </TextBlock>
+      </Example>
+      <Example title="A simple XAML radio group." code={example9jsx}>
+        <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
+          <View>
+            <RadioButton content="Option 1" tag="1" isChecked={true} onChecked={onRadioButtonSelected}/>
+            <RadioButton content="Option 2" tag="2" onChecked={onRadioButtonSelected}/>
+            <RadioButton content="Option 3" tag="3" onChecked={onRadioButtonSelected}/>
+          </View>
+          <Text>{`Output:
+You selected Option ${selectedRadioButton}`}</Text>
+        </View>
       </Example>
       <Example title="A simple ComboBox." code={example5jsx}>
         <ComboBox accessibilityLabel="Simple example ComboBox" text="ComboBox">


### PR DESCRIPTION
## Description

### Why

Radio buttons are a common UX primitive on desktop, and "how do I create radio groups with RNW" is a question that comes up.

### What

Adds 2 examples that demonstrates how to use radio buttons:
- Sample that uses the `react-native-radio-buttons-group` community module
- Add an example to the `react-native-xaml` page that shows how to use XAML's radio button types

## Screenshots

![image](https://github.com/microsoft/react-native-gallery/assets/26607885/a57dc5ec-2031-4279-aa5e-3a31938e5109)

![image](https://github.com/microsoft/react-native-gallery/assets/26607885/2cfba12b-4ab9-49a4-9130-81283fd1b61b)

