### PR TITLE
Fix badges in dark mode

### DIFF
--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -1295,7 +1295,7 @@ exports[`CheckBox Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "SystemColorHighlightTextColor",
+                    "CardBackgroundFillColorDefaultBrush",
                   ],
                 },
               },
@@ -1340,7 +1340,11 @@ exports[`CheckBox Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }
@@ -2432,7 +2436,11 @@ exports[`Clipboard Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }
@@ -3340,7 +3348,11 @@ exports[`Config Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }
@@ -3975,7 +3987,11 @@ exports[`DeviceInfo Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }
@@ -4737,7 +4753,7 @@ exports[`Expander Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "SystemColorHighlightTextColor",
+                    "CardBackgroundFillColorDefaultBrush",
                   ],
                 },
               },
@@ -4782,7 +4798,11 @@ exports[`Expander Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }
@@ -6171,7 +6191,7 @@ exports[`Expander Example Page 1`] = `
                       undefined,
                     ]
                   }
-                  timeZoneOffsetInSeconds={-0}
+                  timeZoneOffsetInSeconds={-28800}
                 />
               </ExpanderView>
             </View>
@@ -9071,7 +9091,7 @@ exports[`Flyout Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "SystemColorHighlightTextColor",
+                    "CardBackgroundFillColorDefaultBrush",
                   ],
                 },
               },
@@ -12207,7 +12227,7 @@ exports[`Hello Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "SystemColorHighlightTextColor",
+                    "CardBackgroundFillColorDefaultBrush",
                   ],
                 },
               },
@@ -12252,7 +12272,11 @@ exports[`Hello Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }
@@ -13426,7 +13450,7 @@ exports[`Image Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "SystemColorHighlightTextColor",
+                    "CardBackgroundFillColorDefaultBrush",
                   ],
                 },
               },
@@ -13471,7 +13495,11 @@ exports[`Image Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }
@@ -14861,7 +14889,7 @@ exports[`Picker Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "SystemColorHighlightTextColor",
+                    "CardBackgroundFillColorDefaultBrush",
                   ],
                 },
               },
@@ -14906,7 +14934,11 @@ exports[`Picker Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }
@@ -16590,7 +16622,7 @@ exports[`Popup Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "SystemColorHighlightTextColor",
+                    "CardBackgroundFillColorDefaultBrush",
                   ],
                 },
               },
@@ -21976,7 +22008,11 @@ exports[`Print Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }
@@ -22564,7 +22600,11 @@ exports[`ProgressView Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }
@@ -23198,7 +23238,7 @@ exports[`ScrollView Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "SystemColorHighlightTextColor",
+                    "CardBackgroundFillColorDefaultBrush",
                   ],
                 },
               },
@@ -24740,7 +24780,11 @@ exports[`SensitiveInfo Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }
@@ -26467,7 +26511,7 @@ exports[`Slider Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "SystemColorHighlightTextColor",
+                    "CardBackgroundFillColorDefaultBrush",
                   ],
                 },
               },
@@ -26512,7 +26556,11 @@ exports[`Slider Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }
@@ -27701,7 +27749,7 @@ exports[`Switch Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "SystemColorHighlightTextColor",
+                    "CardBackgroundFillColorDefaultBrush",
                   ],
                 },
               },
@@ -28418,7 +28466,7 @@ exports[`Text Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "SystemColorHighlightTextColor",
+                    "CardBackgroundFillColorDefaultBrush",
                   ],
                 },
               },
@@ -30045,7 +30093,7 @@ exports[`TextInput Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "SystemColorHighlightTextColor",
+                    "CardBackgroundFillColorDefaultBrush",
                   ],
                 },
               },
@@ -31107,7 +31155,11 @@ exports[`TextToSpeech Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }
@@ -35789,7 +35841,7 @@ exports[`View Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "SystemColorHighlightTextColor",
+                    "CardBackgroundFillColorDefaultBrush",
                   ],
                 },
               },
@@ -39468,7 +39520,7 @@ exports[`WebView Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "SystemColorHighlightTextColor",
+                    "CardBackgroundFillColorDefaultBrush",
                   ],
                 },
               },
@@ -39513,7 +39565,11 @@ exports[`WebView Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }
@@ -40203,7 +40259,11 @@ exports[`Xaml Example Page 1`] = `
                 "paddingTop": 5,
               },
               {
-                "backgroundColor": "rgb(28, 28, 30)",
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
               },
             ]
           }

--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -6191,7 +6191,7 @@ exports[`Expander Example Page 1`] = `
                       undefined,
                     ]
                   }
-                  timeZoneOffsetInSeconds={-28800}
+                  timeZoneOffsetInSeconds={-0}
                 />
               </ExpanderView>
             </View>

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {StyleSheet, View, Text} from 'react-native';
+import {StyleSheet, View, Text, OpaqueColorValue} from 'react-native';
 import {SymbolIcon} from 'react-native-xaml';
 
 const styles = StyleSheet.create({
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
 });
 
 export function Badge(props: {
-  badgeColor: string;
+  badgeColor: OpaqueColorValue;
   textColor: string;
   badgeTitle: string;
   icon: number;

--- a/src/components/CommunityModuleBadge.tsx
+++ b/src/components/CommunityModuleBadge.tsx
@@ -7,7 +7,7 @@ export function CommunityModuleBadge() {
   const {colors} = useTheme();
   return (
     <Badge
-      badgeColor={colors.text}
+      badgeColor={PlatformColor('AccentFillColorDefaultBrush')}
       textColor={
         Platform.OS === 'windows'
           ? PlatformColor('SystemColorHighlightTextColor')

--- a/src/components/NativeControlBadge.tsx
+++ b/src/components/NativeControlBadge.tsx
@@ -9,7 +9,7 @@ export function NativeControlBadge() {
     <Badge
       badgeColor={
         Platform.OS === 'windows'
-          ? PlatformColor('SystemColorHighlightTextColor')
+          ? PlatformColor('CardBackgroundFillColorDefaultBrush')
           : colors.border
       }
       textColor={colors.text}


### PR DESCRIPTION
## Description

### Why

Badges displayed incorrectly in dark mode.

In light mode:
![image](https://github.com/microsoft/react-native-gallery/assets/26607885/6a2459a8-3ca1-46cc-98cf-e42120038188)
In dark mode:
![image](https://github.com/microsoft/react-native-gallery/assets/26607885/35f533f0-b7b9-4bab-9791-c1e6226b77ac)


### What

Moves to `PlatformColor` styles from XAML, which support light/dark mode.

## Screenshots

![image](https://github.com/microsoft/react-native-gallery/assets/26607885/3eac407e-8cf5-4c81-a576-5078629d5226)
![image](https://github.com/microsoft/react-native-gallery/assets/26607885/c948815b-e4c5-4f59-8072-c895828a67ea)
