### PR TITLE
Add "copy to clipboard" to code blocks

### DIFF
--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -252,7 +252,7 @@ exports[`Button Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -260,6 +260,11 @@ exports[`Button Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -351,16 +356,22 @@ exports[`Button Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -404,6 +415,85 @@ exports[`Button Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -425,7 +515,7 @@ exports[`Button Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -433,6 +523,11 @@ exports[`Button Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -535,16 +630,22 @@ exports[`Button Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -588,6 +689,85 @@ exports[`Button Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -609,7 +789,7 @@ exports[`Button Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -617,6 +797,11 @@ exports[`Button Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -729,16 +914,22 @@ exports[`Button Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -796,6 +987,85 @@ exports[`Button Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -817,7 +1087,7 @@ exports[`Button Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -825,6 +1095,11 @@ exports[`Button Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -917,16 +1192,22 @@ exports[`Button Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -988,6 +1269,85 @@ exports[`Button Example Page 1`] = `
 /&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -1420,7 +1780,7 @@ exports[`CheckBox Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -1428,6 +1788,11 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -1451,16 +1816,22 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -1479,6 +1850,85 @@ exports[`CheckBox Example Page 1`] = `
                     &lt;CheckBox /&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -1501,7 +1951,7 @@ exports[`CheckBox Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -1509,6 +1959,11 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -1533,16 +1988,22 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -1576,6 +2037,85 @@ exports[`CheckBox Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -1597,7 +2137,7 @@ exports[`CheckBox Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -1605,6 +2145,11 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -1629,16 +2174,22 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -1657,6 +2208,85 @@ exports[`CheckBox Example Page 1`] = `
                     &lt;CheckBox disabled /&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -1679,7 +2309,7 @@ exports[`CheckBox Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -1687,6 +2317,11 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -1712,16 +2347,22 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -1755,6 +2396,85 @@ exports[`CheckBox Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -1776,7 +2496,7 @@ exports[`CheckBox Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -1784,6 +2504,11 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -1809,16 +2534,22 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -1852,6 +2583,85 @@ exports[`CheckBox Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -1873,7 +2683,7 @@ exports[`CheckBox Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -1881,6 +2691,11 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -1906,16 +2721,22 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -1949,6 +2770,85 @@ exports[`CheckBox Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -1970,7 +2870,7 @@ exports[`CheckBox Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -1978,6 +2878,11 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -2003,16 +2908,22 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -2046,6 +2957,85 @@ exports[`CheckBox Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -2067,7 +3057,7 @@ exports[`CheckBox Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -2075,6 +3065,11 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -2099,16 +3094,22 @@ exports[`CheckBox Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -2127,6 +3128,85 @@ exports[`CheckBox Example Page 1`] = `
                     &lt;CheckBox tintColor={colors.primary} /&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -2512,7 +3592,7 @@ exports[`Clipboard Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -2520,6 +3600,11 @@ exports[`Clipboard Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -2623,16 +3708,22 @@ exports[`Clipboard Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -2678,6 +3769,85 @@ exports[`Clipboard Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -2699,7 +3869,7 @@ exports[`Clipboard Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -2707,6 +3877,11 @@ exports[`Clipboard Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -2807,16 +3982,22 @@ exports[`Clipboard Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -3044,6 +4225,85 @@ exports[`Clipboard Example Page 1`] = `
                     </Text>
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -3420,7 +4680,7 @@ exports[`Config Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -3428,6 +4688,11 @@ exports[`Config Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -3463,16 +4728,22 @@ exports[`Config Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -3675,6 +4946,85 @@ exports[`Config Example Page 1`] = `
 &lt;/&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -4055,7 +5405,7 @@ exports[`DeviceInfo Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -4063,6 +5413,11 @@ exports[`DeviceInfo Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -4091,16 +5446,22 @@ exports[`DeviceInfo Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -4243,6 +5604,85 @@ exports[`DeviceInfo Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -4264,7 +5704,7 @@ exports[`DeviceInfo Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -4272,6 +5712,11 @@ exports[`DeviceInfo Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -4293,16 +5738,22 @@ exports[`DeviceInfo Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -4364,6 +5815,85 @@ exports[`DeviceInfo Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -4385,7 +5915,7 @@ exports[`DeviceInfo Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -4393,6 +5923,11 @@ exports[`DeviceInfo Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -4411,16 +5946,22 @@ exports[`DeviceInfo Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -4439,6 +5980,85 @@ exports[`DeviceInfo Example Page 1`] = `
                     &lt;Text&gt;IP address: {ipAddress}&lt;/Text&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -4862,7 +6482,7 @@ exports[`Expander Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -4870,6 +6490,11 @@ exports[`Expander Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -4892,16 +6517,22 @@ exports[`Expander Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -5072,6 +6703,85 @@ exports[`Expander Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -5093,7 +6803,7 @@ exports[`Expander Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -5101,6 +6811,11 @@ exports[`Expander Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -5133,16 +6848,22 @@ exports[`Expander Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -5543,6 +7264,85 @@ exports[`Expander Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -5564,7 +7364,7 @@ exports[`Expander Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -5572,6 +7372,11 @@ exports[`Expander Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -5595,16 +7400,22 @@ exports[`Expander Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -5789,6 +7600,85 @@ exports[`Expander Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -5810,7 +7700,7 @@ exports[`Expander Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -5818,6 +7708,11 @@ exports[`Expander Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -5844,16 +7739,22 @@ exports[`Expander Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -6086,6 +7987,85 @@ exports[`Expander Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -6107,7 +8087,7 @@ exports[`Expander Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -6115,6 +8095,11 @@ exports[`Expander Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -6171,23 +8156,29 @@ exports[`Expander Example Page 1`] = `
                       undefined,
                     ]
                   }
-                  timeZoneOffsetInSeconds={-0}
+                  timeZoneOffsetInSeconds={-28800}
                 />
               </ExpanderView>
             </View>
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -6760,6 +8751,85 @@ exports[`Expander Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -7144,7 +9214,7 @@ exports[`FlatList Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -7152,6 +9222,11 @@ exports[`FlatList Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -7319,16 +9394,22 @@ exports[`FlatList Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -7371,6 +9452,85 @@ exports[`FlatList Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -7392,7 +9552,7 @@ exports[`FlatList Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -7400,6 +9560,11 @@ exports[`FlatList Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -7620,16 +9785,22 @@ exports[`FlatList Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -7886,6 +10057,85 @@ exports[`FlatList Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -7907,7 +10157,7 @@ exports[`FlatList Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -7915,6 +10165,11 @@ exports[`FlatList Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -8163,16 +10418,22 @@ exports[`FlatList Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -8245,6 +10506,85 @@ exports[`FlatList Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -8266,7 +10606,7 @@ exports[`FlatList Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -8274,6 +10614,11 @@ exports[`FlatList Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -8408,16 +10753,22 @@ exports[`FlatList Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -8504,6 +10855,85 @@ exports[`FlatList Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -8525,7 +10955,7 @@ exports[`FlatList Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -8533,6 +10963,11 @@ exports[`FlatList Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -8698,16 +11133,22 @@ exports[`FlatList Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -8764,6 +11205,85 @@ exports[`FlatList Example Page 1`] = `
                     }/&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -9196,7 +11716,7 @@ exports[`Flyout Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -9204,6 +11724,11 @@ exports[`Flyout Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -9338,16 +11863,22 @@ exports[`Flyout Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -9854,6 +12385,85 @@ exports[`Flyout Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -9875,7 +12485,7 @@ exports[`Flyout Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -9883,6 +12493,11 @@ exports[`Flyout Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -10018,16 +12633,22 @@ exports[`Flyout Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -10535,6 +13156,85 @@ exports[`Flyout Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -10556,7 +13256,7 @@ exports[`Flyout Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -10564,6 +13264,11 @@ exports[`Flyout Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -10700,16 +13405,22 @@ exports[`Flyout Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -11218,6 +13929,85 @@ exports[`Flyout Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -11239,7 +14029,7 @@ exports[`Flyout Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -11247,6 +14037,11 @@ exports[`Flyout Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -11382,16 +14177,22 @@ exports[`Flyout Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -11901,6 +14702,85 @@ exports[`Flyout Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -12332,7 +15212,7 @@ exports[`Hello Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -12340,6 +15220,11 @@ exports[`Hello Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -12433,16 +15318,22 @@ exports[`Hello Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -12576,6 +15467,85 @@ exports[`Hello Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -12597,7 +15567,7 @@ exports[`Hello Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -12605,6 +15575,11 @@ exports[`Hello Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -12698,16 +15673,22 @@ exports[`Hello Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -12841,6 +15822,85 @@ exports[`Hello Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -12862,7 +15922,7 @@ exports[`Hello Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -12870,6 +15930,11 @@ exports[`Hello Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -12963,16 +16028,22 @@ exports[`Hello Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -13119,6 +16190,85 @@ exports[`Hello Example Page 1`] = `
   });
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -13551,7 +16701,7 @@ exports[`Image Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -13559,6 +16709,11 @@ exports[`Image Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -13580,16 +16735,22 @@ exports[`Image Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -13697,6 +16858,85 @@ exports[`Image Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -13718,7 +16958,7 @@ exports[`Image Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -13726,6 +16966,11 @@ exports[`Image Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -13748,16 +16993,22 @@ exports[`Image Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -13880,6 +17131,85 @@ exports[`Image Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -13901,7 +17231,7 @@ exports[`Image Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -13909,6 +17239,11 @@ exports[`Image Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -13931,16 +17266,22 @@ exports[`Image Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -14061,6 +17402,85 @@ exports[`Image Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -14082,7 +17502,7 @@ exports[`Image Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -14090,6 +17510,11 @@ exports[`Image Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -14113,16 +17538,22 @@ exports[`Image Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -14271,6 +17702,85 @@ exports[`Image Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -14292,7 +17802,7 @@ exports[`Image Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -14300,6 +17810,11 @@ exports[`Image Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -14325,16 +17840,22 @@ exports[`Image Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -14545,6 +18066,85 @@ exports[`Image Example Page 1`] = `
 /&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -14986,7 +18586,7 @@ exports[`Picker Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -14994,6 +18594,11 @@ exports[`Picker Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -15042,16 +18647,22 @@ exports[`Picker Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -15395,6 +19006,85 @@ exports[`Picker Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -15416,7 +19106,7 @@ exports[`Picker Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -15424,6 +19114,11 @@ exports[`Picker Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -15473,16 +19168,22 @@ exports[`Picker Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -15840,6 +19541,85 @@ exports[`Picker Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -15861,7 +19641,7 @@ exports[`Picker Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -15869,6 +19649,11 @@ exports[`Picker Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -15917,16 +19702,22 @@ exports[`Picker Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -16283,6 +20074,85 @@ exports[`Picker Example Page 1`] = `
 &lt;/Picker&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -16715,7 +20585,7 @@ exports[`Popup Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -16723,6 +20593,11 @@ exports[`Popup Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -16918,16 +20793,22 @@ exports[`Popup Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -17402,6 +21283,85 @@ exports[`Popup Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -17423,7 +21383,7 @@ exports[`Popup Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -17431,6 +21391,11 @@ exports[`Popup Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -17627,16 +21592,22 @@ exports[`Popup Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -18172,6 +22143,85 @@ exports[`Popup Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -18193,7 +22243,7 @@ exports[`Popup Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -18201,6 +22251,11 @@ exports[`Popup Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -18398,16 +22453,22 @@ exports[`Popup Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -18916,6 +22977,85 @@ exports[`Popup Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -18937,7 +23077,7 @@ exports[`Popup Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -18945,6 +23085,11 @@ exports[`Popup Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -19140,16 +23285,22 @@ exports[`Popup Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -19658,6 +23809,85 @@ exports[`Popup Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -20051,7 +24281,7 @@ exports[`Pressable Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -20059,6 +24289,11 @@ exports[`Pressable Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -20115,16 +24350,22 @@ exports[`Pressable Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -20226,6 +24467,85 @@ exports[`Pressable Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -20247,7 +24567,7 @@ exports[`Pressable Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -20255,6 +24575,11 @@ exports[`Pressable Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -20325,16 +24650,22 @@ exports[`Pressable Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -20658,6 +24989,85 @@ exports[`Pressable Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -20679,7 +25089,7 @@ exports[`Pressable Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -20687,6 +25097,11 @@ exports[`Pressable Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -20759,16 +25174,22 @@ exports[`Pressable Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -21206,6 +25627,85 @@ exports[`Pressable Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -21227,7 +25727,7 @@ exports[`Pressable Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -21235,6 +25735,11 @@ exports[`Pressable Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -21305,16 +25810,22 @@ exports[`Pressable Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -21671,6 +26182,85 @@ exports[`Pressable Example Page 1`] = `
 &lt;/Pressable&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -22056,7 +26646,7 @@ exports[`Print Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -22064,6 +26654,11 @@ exports[`Print Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -22162,16 +26757,22 @@ exports[`Print Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -22268,6 +26869,85 @@ exports[`Print Example Page 1`] = `
                      /&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -22644,7 +27324,7 @@ exports[`ProgressView Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -22652,6 +27332,11 @@ exports[`ProgressView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -22671,16 +27356,22 @@ exports[`ProgressView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -22714,6 +27405,85 @@ exports[`ProgressView Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -22735,7 +27505,7 @@ exports[`ProgressView Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -22743,6 +27513,11 @@ exports[`ProgressView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -22762,16 +27537,22 @@ exports[`ProgressView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -22805,6 +27586,85 @@ exports[`ProgressView Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -22826,7 +27686,7 @@ exports[`ProgressView Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -22834,6 +27694,11 @@ exports[`ProgressView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -22855,16 +27720,22 @@ exports[`ProgressView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -22900,6 +27771,85 @@ exports[`ProgressView Example Page 1`] = `
                     } /&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -23323,7 +28273,7 @@ exports[`ScrollView Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -23331,6 +28281,11 @@ exports[`ScrollView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -23358,16 +28313,22 @@ exports[`ScrollView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -23489,6 +28450,85 @@ exports[`ScrollView Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -23510,7 +28550,7 @@ exports[`ScrollView Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -23518,6 +28558,11 @@ exports[`ScrollView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -23546,16 +28591,22 @@ exports[`ScrollView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -23686,6 +28737,85 @@ exports[`ScrollView Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -23707,7 +28837,7 @@ exports[`ScrollView Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -23715,6 +28845,11 @@ exports[`ScrollView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -23743,16 +28878,22 @@ exports[`ScrollView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -23888,6 +29029,85 @@ exports[`ScrollView Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -23909,7 +29129,7 @@ exports[`ScrollView Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -23917,6 +29137,11 @@ exports[`ScrollView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -23968,16 +29193,22 @@ exports[`ScrollView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -24427,6 +29658,85 @@ exports[`ScrollView Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -24820,7 +30130,7 @@ exports[`SensitiveInfo Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -24828,6 +30138,11 @@ exports[`SensitiveInfo Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -25102,16 +30417,22 @@ exports[`SensitiveInfo Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -26170,6 +31491,85 @@ exports[`SensitiveInfo Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -26592,7 +31992,7 @@ exports[`Slider Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -26600,6 +32000,11 @@ exports[`Slider Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -26636,16 +32041,22 @@ exports[`Slider Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -26767,6 +32178,85 @@ exports[`Slider Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -26788,7 +32278,7 @@ exports[`Slider Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -26796,6 +32286,11 @@ exports[`Slider Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -26832,16 +32327,22 @@ exports[`Slider Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -26963,6 +32464,85 @@ exports[`Slider Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -26984,7 +32564,7 @@ exports[`Slider Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -26992,6 +32572,11 @@ exports[`Slider Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -27031,16 +32616,22 @@ exports[`Slider Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -27179,6 +32770,85 @@ exports[`Slider Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -27200,7 +32870,7 @@ exports[`Slider Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -27208,6 +32878,11 @@ exports[`Slider Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -27249,16 +32924,22 @@ exports[`Slider Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -27394,6 +33075,85 @@ exports[`Slider Example Page 1`] = `
                     } /&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -27826,7 +33586,7 @@ exports[`Switch Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -27834,6 +33594,11 @@ exports[`Switch Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -27857,16 +33622,22 @@ exports[`Switch Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -27887,6 +33658,85 @@ exports[`Switch Example Page 1`] = `
   onValueChange={onSwitchChange1} /&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -27909,7 +33759,7 @@ exports[`Switch Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -27917,6 +33767,11 @@ exports[`Switch Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -27941,16 +33796,22 @@ exports[`Switch Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -27973,6 +33834,85 @@ exports[`Switch Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -27994,7 +33934,7 @@ exports[`Switch Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -28002,6 +33942,11 @@ exports[`Switch Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -28028,16 +33973,22 @@ exports[`Switch Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -28102,6 +34053,85 @@ exports[`Switch Example Page 1`] = `
                     : colors.primary}} /&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -28543,7 +34573,7 @@ exports[`Text Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -28551,6 +34581,11 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -28568,16 +34603,22 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -28611,6 +34652,85 @@ exports[`Text Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -28632,7 +34752,7 @@ exports[`Text Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -28640,6 +34760,11 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -28659,16 +34784,22 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -28760,6 +34891,85 @@ exports[`Text Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -28781,7 +34991,7 @@ exports[`Text Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -28789,6 +34999,11 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -28807,16 +35022,22 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -28866,6 +35087,85 @@ exports[`Text Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -28887,7 +35187,7 @@ exports[`Text Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -28895,6 +35195,11 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -28914,16 +35219,22 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -29061,6 +35372,85 @@ exports[`Text Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -29082,7 +35472,7 @@ exports[`Text Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -29090,6 +35480,11 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -29126,16 +35521,22 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -29233,6 +35634,85 @@ exports[`Text Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -29254,7 +35734,7 @@ exports[`Text Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -29262,6 +35742,11 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -29280,16 +35765,22 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -29382,6 +35873,85 @@ exports[`Text Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -29403,7 +35973,7 @@ exports[`Text Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -29411,6 +35981,11 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -29429,16 +36004,22 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -29548,6 +36129,85 @@ exports[`Text Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -29569,7 +36229,7 @@ exports[`Text Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -29577,6 +36237,11 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -29596,16 +36261,22 @@ exports[`Text Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -29729,6 +36400,85 @@ Here is a line
 &lt;/Text&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -30170,7 +36920,7 @@ exports[`TextInput Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -30178,6 +36928,11 @@ exports[`TextInput Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -30198,16 +36953,22 @@ exports[`TextInput Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -30272,6 +37033,85 @@ exports[`TextInput Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -30293,7 +37133,7 @@ exports[`TextInput Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -30301,6 +37141,11 @@ exports[`TextInput Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -30322,16 +37167,22 @@ exports[`TextInput Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -30412,6 +37263,85 @@ exports[`TextInput Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -30433,7 +37363,7 @@ exports[`TextInput Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -30441,6 +37371,11 @@ exports[`TextInput Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -30465,16 +37400,22 @@ exports[`TextInput Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -30630,6 +37571,85 @@ exports[`TextInput Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -30651,7 +37671,7 @@ exports[`TextInput Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -30659,6 +37679,11 @@ exports[`TextInput Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -30680,16 +37705,22 @@ exports[`TextInput Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -30784,6 +37815,85 @@ exports[`TextInput Example Page 1`] = `
   placeholderTextColor={colors.primary}/&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -31187,7 +38297,7 @@ exports[`TextToSpeech Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -31195,6 +38305,11 @@ exports[`TextToSpeech Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -31344,16 +38459,22 @@ exports[`TextToSpeech Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -31423,6 +38544,85 @@ exports[`TextToSpeech Example Page 1`] = `
   
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -31801,7 +39001,7 @@ exports[`TouchableHighlight Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -31809,6 +39009,11 @@ exports[`TouchableHighlight Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -31867,16 +39072,22 @@ exports[`TouchableHighlight Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -32160,6 +39371,85 @@ exports[`TouchableHighlight Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -32181,7 +39471,7 @@ exports[`TouchableHighlight Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -32189,6 +39479,11 @@ exports[`TouchableHighlight Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -32243,16 +39538,22 @@ exports[`TouchableHighlight Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -32536,6 +39837,85 @@ exports[`TouchableHighlight Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -32557,7 +39937,7 @@ exports[`TouchableHighlight Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -32565,6 +39945,11 @@ exports[`TouchableHighlight Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -32624,16 +40009,22 @@ exports[`TouchableHighlight Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -32932,6 +40323,85 @@ exports[`TouchableHighlight Example Page 1`] = `
 &lt;/TouchableHighlight&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -33317,7 +40787,7 @@ exports[`TouchableOpacity Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -33325,6 +40795,11 @@ exports[`TouchableOpacity Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -33395,16 +40870,22 @@ exports[`TouchableOpacity Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -33716,6 +41197,85 @@ exports[`TouchableOpacity Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -33737,7 +41297,7 @@ exports[`TouchableOpacity Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -33745,6 +41305,11 @@ exports[`TouchableOpacity Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -33811,16 +41376,22 @@ exports[`TouchableOpacity Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -34132,6 +41703,85 @@ exports[`TouchableOpacity Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -34153,7 +41803,7 @@ exports[`TouchableOpacity Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -34161,6 +41811,11 @@ exports[`TouchableOpacity Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -34232,16 +41887,22 @@ exports[`TouchableOpacity Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -34568,6 +42229,85 @@ exports[`TouchableOpacity Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -34589,7 +42329,7 @@ exports[`TouchableOpacity Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -34597,6 +42337,11 @@ exports[`TouchableOpacity Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -34668,16 +42413,22 @@ exports[`TouchableOpacity Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -35005,6 +42756,85 @@ activeOpacity={
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -35026,7 +42856,7 @@ activeOpacity={
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -35034,6 +42864,11 @@ activeOpacity={
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -35104,16 +42939,22 @@ activeOpacity={
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -35482,6 +43323,85 @@ onPress={
 &lt;/TouchableOpacity&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -35914,7 +43834,7 @@ exports[`View Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -35922,6 +43842,11 @@ exports[`View Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -35931,16 +43856,22 @@ exports[`View Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -35959,6 +43890,85 @@ exports[`View Example Page 1`] = `
                     &lt;View /&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -35981,7 +43991,7 @@ exports[`View Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -35989,6 +43999,11 @@ exports[`View Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -36007,16 +44022,22 @@ exports[`View Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -36140,6 +44161,85 @@ exports[`View Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -36161,7 +44261,7 @@ exports[`View Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -36169,6 +44269,11 @@ exports[`View Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -36204,16 +44309,22 @@ exports[`View Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -36557,6 +44668,85 @@ exports[`View Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -36578,7 +44768,7 @@ exports[`View Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -36586,6 +44776,11 @@ exports[`View Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -36622,16 +44817,22 @@ exports[`View Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -37041,6 +45242,85 @@ exports[`View Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -37062,7 +45342,7 @@ exports[`View Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -37070,6 +45350,11 @@ exports[`View Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -37120,16 +45405,22 @@ exports[`View Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -37834,6 +46125,85 @@ exports[`View Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -37855,7 +46225,7 @@ exports[`View Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -37863,6 +46233,11 @@ exports[`View Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -37904,16 +46279,22 @@ exports[`View Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -38468,6 +46849,85 @@ exports[`View Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -38489,7 +46949,7 @@ exports[`View Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -38497,6 +46957,11 @@ exports[`View Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -38518,16 +46983,22 @@ exports[`View Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -38725,6 +47196,85 @@ style={{
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -38746,7 +47296,7 @@ style={{
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -38754,6 +47304,11 @@ style={{
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -38775,16 +47330,22 @@ style={{
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -38982,6 +47543,85 @@ style={{
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -39003,7 +47643,7 @@ style={{
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -39011,6 +47651,11 @@ style={{
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -39030,16 +47675,22 @@ style={{
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -39152,6 +47803,85 @@ style={{
                     </Text>
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -39593,7 +48323,7 @@ exports[`WebView Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -39601,6 +48331,11 @@ exports[`WebView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -39646,16 +48381,22 @@ exports[`WebView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -39735,6 +48476,85 @@ exports[`WebView Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -39756,7 +48576,7 @@ exports[`WebView Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -39764,6 +48584,11 @@ exports[`WebView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -39809,16 +48634,22 @@ exports[`WebView Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -39898,6 +48729,85 @@ exports[`WebView Example Page 1`] = `
   useWebView2 /&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -40283,7 +49193,7 @@ exports[`Xaml Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -40291,6 +49201,11 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -40303,16 +49218,22 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -40346,6 +49267,85 @@ exports[`Xaml Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -40367,7 +49367,7 @@ exports[`Xaml Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -40375,6 +49375,11 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -40392,16 +49397,22 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -40459,6 +49470,85 @@ exports[`Xaml Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -40480,7 +49570,7 @@ exports[`Xaml Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -40488,6 +49578,11 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -40500,16 +49595,22 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -40528,6 +49629,85 @@ exports[`Xaml Example Page 1`] = `
                     &lt;ToggleSwitch /&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>
@@ -40550,7 +49730,7 @@ exports[`Xaml Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -40558,6 +49738,11 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -40587,16 +49772,22 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -40886,6 +50077,85 @@ exports[`Xaml Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -40907,7 +50177,7 @@ exports[`Xaml Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -40915,6 +50185,11 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -40953,16 +50228,22 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -41264,6 +50545,85 @@ exports[`Xaml Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -41285,7 +50645,7 @@ exports[`Xaml Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -41293,6 +50653,11 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -41306,16 +50671,22 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -41349,6 +50720,85 @@ exports[`Xaml Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -41370,7 +50820,7 @@ exports[`Xaml Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -41378,6 +50828,11 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -41423,16 +50878,22 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -41913,6 +51374,85 @@ exports[`Xaml Example Page 1`] = `
                   </Text>
                 </Text>
               </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -41934,7 +51474,7 @@ exports[`Xaml Example Page 1`] = `
             style={
               {
                 "borderColor": "rgb(216, 216, 216)",
-                "borderRadius": 2,
+                "borderRadius": 8,
                 "borderWidth": 1,
               }
             }
@@ -41942,6 +51482,11 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
                   "padding": 15,
                 }
               }
@@ -41986,16 +51531,22 @@ exports[`Xaml Example Page 1`] = `
             <View
               style={
                 {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
                   "borderColor": "rgb(216, 216, 216)",
                   "borderTopWidth": 1,
                   "borderWidth": 0,
+                  "padding": 12,
                 }
               }
             >
               <View
                 style={
                   {
-                    "backgroundColor": "#E6E6E6",
+                    "backgroundColor": "transparent",
                     "flexGrow": 1,
                     "padding": 5,
                   }
@@ -42477,6 +52028,85 @@ exports[`Xaml Example Page 1`] = `
 &lt;/NavigationView&gt;
                   </Text>
                 </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
               </View>
             </View>
           </View>

--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -8156,7 +8156,7 @@ exports[`Expander Example Page 1`] = `
                       undefined,
                     ]
                   }
-                  timeZoneOffsetInSeconds={-28800}
+                  timeZoneOffsetInSeconds={-0}
                 />
               </ExpanderView>
             </View>

--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -5,7 +5,7 @@ import {StyleSheet, Text, View} from 'react-native';
 import {ThemeContext} from '../themes/Theme';
 
 const darkColors = {
-  background: '#1E1E1E',
+  background: 'transparent',
   text: '#9cdcfe',
   comment: '#6a9955',
   keyword: '#c586c0',
@@ -19,7 +19,7 @@ const darkColors = {
 };
 
 const lightColors = {
-  background: '#E6E6E6',
+  background: 'transparent',
   text: '#000000',
   comment: '#000000',
   keyword: '#FF0000',

--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {Pressable, StyleSheet, PlatformColor, Text} from 'react-native';
+import Clipboard from '@react-native-clipboard/clipboard';
+
+const createButtonStyles = (isHovered: boolean, isPressing: boolean) =>
+  StyleSheet.create({
+    background: {
+      backgroundColor: isPressing
+        ? PlatformColor('ControlFillColorTertiaryBrush')
+        : isHovered
+        ? PlatformColor('ControlFillColorSecondaryBrush')
+        : PlatformColor('ControlFillColorDefaultBrush'),
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: PlatformColor('ControlStrokeColorDefaultBrush'),
+      padding: 6,
+    },
+    text: {
+      fontFamily: 'Segoe MDL2 Assets',
+      fontSize: 16,
+      color: PlatformColor('TextControlForeground'),
+    },
+  });
+
+type CopyToClipboardButtonProps = {
+  content: string;
+};
+const CopyToClipboardButton = ({content}: CopyToClipboardButtonProps) => {
+  const [isHovered, setIsHovered] = React.useState(false);
+  const [isPressing, setIsPressing] = React.useState(false);
+  const styles = createButtonStyles(isHovered, isPressing);
+
+  const copyIcon = '\uE8C8';
+
+  return (
+    <Pressable
+      tooltip={'Copy to clipboard'}
+      style={styles.background}
+      onPress={() => Clipboard.setString(content)}
+      onPressIn={() => setIsPressing(true)}
+      onPressOut={() => setIsPressing(false)}
+      onHoverIn={() => setIsHovered(true)}
+      onHoverOut={() => setIsHovered(false)}>
+      <Text style={styles.text}>{copyIcon}</Text>
+    </Pressable>
+  );
+};
+
+export {CopyToClipboardButton};

--- a/src/components/Example.tsx
+++ b/src/components/Example.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {Code} from './Code';
-import {StyleSheet, Text, View} from 'react-native';
+import {Pressable, StyleSheet, PlatformColor, Text, View} from 'react-native';
 import {useTheme} from '@react-navigation/native';
+import Clipboard from '@react-native-clipboard/clipboard';
 
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -12,19 +13,77 @@ const createStyles = (colors: any) =>
       color: colors.text,
     },
     box: {
-      borderRadius: 2,
+      borderRadius: 8,
       borderWidth: 1,
       borderColor: colors.border,
     },
     exampleContainer: {
       padding: 15,
+      backgroundColor: PlatformColor('SolidBackgroundFillColorSecondaryBrush'),
     },
     codeContainer: {
       borderWidth: 0,
       borderTopWidth: 1,
       borderColor: colors.border,
+      padding: 12,
+      backgroundColor: PlatformColor('CardBackgroundFillColorDefaultBrush'),
+    },
+    copyButton: {
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: colors.border,
+      padding: 6,
+    },
+    copyButtonText: {
+      fontFamily: 'Segoe MDL2 Assets',
+      fontSize: 16,
+      color: PlatformColor('TextControlForeground'),
     },
   });
+
+const createButtonStyles = (isHovered: boolean, isPressing: boolean) =>
+  StyleSheet.create({
+    background: {
+      backgroundColor: isPressing
+        ? PlatformColor('ControlFillColorTertiaryBrush')
+        : isHovered
+        ? PlatformColor('ControlFillColorSecondaryBrush')
+        : PlatformColor('ControlFillColorDefaultBrush'),
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: PlatformColor('ControlStrokeColorDefaultBrush'),
+      padding: 6,
+    },
+    text: {
+      fontFamily: 'Segoe MDL2 Assets',
+      fontSize: 16,
+      color: PlatformColor('TextControlForeground'),
+    },
+  });
+
+type CopyToClipboardButtonProps = {
+  content: string;
+};
+const CopyToClipboardButton = ({content}: CopyToClipboardButtonProps) => {
+  const [isHovered, setIsHovered] = React.useState(false);
+  const [isPressing, setIsPressing] = React.useState(false);
+  const styles = createButtonStyles(isHovered, isPressing);
+
+  const copyIcon = '\uE8C8';
+
+  return (
+    <Pressable
+      tooltip={'Copy to clipboard'}
+      style={styles.background}
+      onPress={() => Clipboard.setString(content)}
+      onPressIn={() => setIsPressing(true)}
+      onPressOut={() => setIsPressing(false)}
+      onHoverIn={() => setIsHovered(true)}
+      onHoverOut={() => setIsHovered(false)}>
+      <Text style={styles.text}>{copyIcon}</Text>
+    </Pressable>
+  );
+};
 
 export function Example(props: {
   title: string;
@@ -43,6 +102,9 @@ export function Example(props: {
           <View style={styles.exampleContainer}>{props.children}</View>
           <View style={styles.codeContainer}>
             <Code>{props.code}</Code>
+            <View style={{position: 'absolute', right: 12, top: 12}}>
+              <CopyToClipboardButton content={props.code} />
+            </View>
           </View>
         </View>
       ) : (

--- a/src/components/Example.tsx
+++ b/src/components/Example.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {Code} from './Code';
-import {Pressable, StyleSheet, PlatformColor, Text, View} from 'react-native';
+import {StyleSheet, PlatformColor, Text, View} from 'react-native';
+import {CopyToClipboardButton} from './CopyToClipboard';
 import {useTheme} from '@react-navigation/native';
-import Clipboard from '@react-native-clipboard/clipboard';
 
 const createStyles = (colors: any) =>
   StyleSheet.create({
@@ -28,62 +28,7 @@ const createStyles = (colors: any) =>
       padding: 12,
       backgroundColor: PlatformColor('CardBackgroundFillColorDefaultBrush'),
     },
-    copyButton: {
-      borderRadius: 8,
-      borderWidth: 1,
-      borderColor: colors.border,
-      padding: 6,
-    },
-    copyButtonText: {
-      fontFamily: 'Segoe MDL2 Assets',
-      fontSize: 16,
-      color: PlatformColor('TextControlForeground'),
-    },
   });
-
-const createButtonStyles = (isHovered: boolean, isPressing: boolean) =>
-  StyleSheet.create({
-    background: {
-      backgroundColor: isPressing
-        ? PlatformColor('ControlFillColorTertiaryBrush')
-        : isHovered
-        ? PlatformColor('ControlFillColorSecondaryBrush')
-        : PlatformColor('ControlFillColorDefaultBrush'),
-      borderRadius: 8,
-      borderWidth: 1,
-      borderColor: PlatformColor('ControlStrokeColorDefaultBrush'),
-      padding: 6,
-    },
-    text: {
-      fontFamily: 'Segoe MDL2 Assets',
-      fontSize: 16,
-      color: PlatformColor('TextControlForeground'),
-    },
-  });
-
-type CopyToClipboardButtonProps = {
-  content: string;
-};
-const CopyToClipboardButton = ({content}: CopyToClipboardButtonProps) => {
-  const [isHovered, setIsHovered] = React.useState(false);
-  const [isPressing, setIsPressing] = React.useState(false);
-  const styles = createButtonStyles(isHovered, isPressing);
-
-  const copyIcon = '\uE8C8';
-
-  return (
-    <Pressable
-      tooltip={'Copy to clipboard'}
-      style={styles.background}
-      onPress={() => Clipboard.setString(content)}
-      onPressIn={() => setIsPressing(true)}
-      onPressOut={() => setIsPressing(false)}
-      onHoverIn={() => setIsHovered(true)}
-      onHoverOut={() => setIsHovered(false)}>
-      <Text style={styles.text}>{copyIcon}</Text>
-    </Pressable>
-  );
-};
 
 export function Example(props: {
   title: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3320,10 +3320,10 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz#d7502533a7c96e25baab86bac965468e0703a8b4"
   integrity sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==
 
-"@react-native-clipboard/clipboard@^1.13.2":
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.13.2.tgz#28adcfc43ed2addddf79a59198ec1b25087c115e"
-  integrity sha512-uVM55oEGc6a6ZmSATDeTcMm55A/C1km5X47g0xaoF0Zagv7N/8RGvLceA5L/izPwflIy78t7XQeJUcnGSib0nA==
+"@react-native-clipboard/clipboard@^1.14.0":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.14.0.tgz#ae3b7b59f51b1da1fc6a362244c18ddec113d1f6"
+  integrity sha512-kDLfA6HzP4T+kfGTEGdbsc2r4q0xQALshRQp8Ph/5YD5qT4CZdgkQM3oloKHIdh+AVks+QjtVHK1cZ1xb0Or7w==
 
 "@react-native-community/checkbox@^0.5.16":
   version "0.5.16"


### PR DESCRIPTION
## Description

### Why

WinUI3 gallery code blocks (and most code documentation website and tools) have a "copy to clipboard" button.

Previously:
![image](https://github.com/microsoft/react-native-gallery/assets/26607885/02cc5a8b-b1e7-4e6f-9ca1-c6351a00beb1)

### What

Adds a copy to clipboard button, and modifies the codeblock styling to match WinUI3 gallery. Clipboard was already a dependency that gallery had, so this is easy to add.

## Screenshots

![image](https://github.com/microsoft/react-native-gallery/assets/26607885/4ac6deb0-4151-466f-99be-549b7cfd6e2f)

![image](https://github.com/microsoft/react-native-gallery/assets/26607885/a57cca8e-dad7-4d1f-9a98-fb343f43a001)

