### PR TITLE
Disable Gallery drawer content when closed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,10 @@ function RenderDrawer(props) {
 function CustomDrawerContent(props) {
   const isDrawerOpen =
     getDrawerStatusFromState(props.navigation.getState()) === 'open';
+
+  if (!isDrawerOpen) {
+    return <View />;
+  }
   return (
     <View style={styles.drawer}>
       <TouchableHighlight

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,9 +164,7 @@ function MyDrawer() {
   let screens = renderScreens();
   return (
     <Drawer.Navigator
-      drawerContent={(props) => (
-        <CustomDrawerContent {...props} drawerType="permanent" />
-      )}
+      drawerContent={(props) => <CustomDrawerContent {...props} />}
       screenOptions={{headerShown: false}}>
       {screens}
     </Drawer.Navigator>


### PR DESCRIPTION
## Description

### Why

When you tab through Gallery, you hit the closed drawer items. Those items should not be keyboard focusable.

Related to #408

### What

Removed the drawer content entirely when the drawer is in the closed state.
Additionally changed the drawer mode to not be "permanent", which didn't seem to be the cause here but also doesn't seem to be necessary.

## Screenshots

Here is gallery with the fix:
https://github.com/microsoft/react-native-gallery/assets/26607885/fcf25e92-450d-4627-8f4d-c8027e3a8f88


