### PR TITLE
Update native badge color

### DIFF
--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -1679,7 +1679,7 @@ exports[`CheckBox Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "LayerFillColorAltBrush",
+                    "SolidBackgroundFillColorSecondaryBrush",
                   ],
                 },
               },
@@ -6445,7 +6445,7 @@ exports[`Expander Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "LayerFillColorAltBrush",
+                    "SolidBackgroundFillColorSecondaryBrush",
                   ],
                 },
               },
@@ -11707,7 +11707,7 @@ exports[`Flyout Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "LayerFillColorAltBrush",
+                    "SolidBackgroundFillColorSecondaryBrush",
                   ],
                 },
               },
@@ -15215,7 +15215,7 @@ exports[`Hello Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "LayerFillColorAltBrush",
+                    "SolidBackgroundFillColorSecondaryBrush",
                   ],
                 },
               },
@@ -16720,7 +16720,7 @@ exports[`Image Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "LayerFillColorAltBrush",
+                    "SolidBackgroundFillColorSecondaryBrush",
                   ],
                 },
               },
@@ -18621,7 +18621,7 @@ exports[`Picker Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "LayerFillColorAltBrush",
+                    "SolidBackgroundFillColorSecondaryBrush",
                   ],
                 },
               },
@@ -20636,7 +20636,7 @@ exports[`Popup Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "LayerFillColorAltBrush",
+                    "SolidBackgroundFillColorSecondaryBrush",
                   ],
                 },
               },
@@ -28380,7 +28380,7 @@ exports[`ScrollView Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "LayerFillColorAltBrush",
+                    "SolidBackgroundFillColorSecondaryBrush",
                   ],
                 },
               },
@@ -32127,7 +32127,7 @@ exports[`Slider Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "LayerFillColorAltBrush",
+                    "SolidBackgroundFillColorSecondaryBrush",
                   ],
                 },
               },
@@ -33737,7 +33737,7 @@ exports[`Switch Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "LayerFillColorAltBrush",
+                    "SolidBackgroundFillColorSecondaryBrush",
                   ],
                 },
               },
@@ -34736,7 +34736,7 @@ exports[`Text Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "LayerFillColorAltBrush",
+                    "SolidBackgroundFillColorSecondaryBrush",
                   ],
                 },
               },
@@ -37095,7 +37095,7 @@ exports[`TextInput Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "LayerFillColorAltBrush",
+                    "SolidBackgroundFillColorSecondaryBrush",
                   ],
                 },
               },
@@ -44061,7 +44061,7 @@ exports[`View Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "LayerFillColorAltBrush",
+                    "SolidBackgroundFillColorSecondaryBrush",
                   ],
                 },
               },
@@ -48562,7 +48562,7 @@ exports[`WebView Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "LayerFillColorAltBrush",
+                    "SolidBackgroundFillColorSecondaryBrush",
                   ],
                 },
               },

--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -1679,7 +1679,7 @@ exports[`CheckBox Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "CardBackgroundFillColorDefaultBrush",
+                    "LayerFillColorAltBrush",
                   ],
                 },
               },
@@ -6445,7 +6445,7 @@ exports[`Expander Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "CardBackgroundFillColorDefaultBrush",
+                    "LayerFillColorAltBrush",
                   ],
                 },
               },
@@ -11707,7 +11707,7 @@ exports[`Flyout Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "CardBackgroundFillColorDefaultBrush",
+                    "LayerFillColorAltBrush",
                   ],
                 },
               },
@@ -15215,7 +15215,7 @@ exports[`Hello Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "CardBackgroundFillColorDefaultBrush",
+                    "LayerFillColorAltBrush",
                   ],
                 },
               },
@@ -16720,7 +16720,7 @@ exports[`Image Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "CardBackgroundFillColorDefaultBrush",
+                    "LayerFillColorAltBrush",
                   ],
                 },
               },
@@ -18621,7 +18621,7 @@ exports[`Picker Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "CardBackgroundFillColorDefaultBrush",
+                    "LayerFillColorAltBrush",
                   ],
                 },
               },
@@ -20636,7 +20636,7 @@ exports[`Popup Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "CardBackgroundFillColorDefaultBrush",
+                    "LayerFillColorAltBrush",
                   ],
                 },
               },
@@ -28380,7 +28380,7 @@ exports[`ScrollView Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "CardBackgroundFillColorDefaultBrush",
+                    "LayerFillColorAltBrush",
                   ],
                 },
               },
@@ -32127,7 +32127,7 @@ exports[`Slider Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "CardBackgroundFillColorDefaultBrush",
+                    "LayerFillColorAltBrush",
                   ],
                 },
               },
@@ -33737,7 +33737,7 @@ exports[`Switch Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "CardBackgroundFillColorDefaultBrush",
+                    "LayerFillColorAltBrush",
                   ],
                 },
               },
@@ -34736,7 +34736,7 @@ exports[`Text Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "CardBackgroundFillColorDefaultBrush",
+                    "LayerFillColorAltBrush",
                   ],
                 },
               },
@@ -37095,7 +37095,7 @@ exports[`TextInput Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "CardBackgroundFillColorDefaultBrush",
+                    "LayerFillColorAltBrush",
                   ],
                 },
               },
@@ -44061,7 +44061,7 @@ exports[`View Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "CardBackgroundFillColorDefaultBrush",
+                    "LayerFillColorAltBrush",
                   ],
                 },
               },
@@ -48562,7 +48562,7 @@ exports[`WebView Example Page 1`] = `
               {
                 "backgroundColor": {
                   "windowsbrush": [
-                    "CardBackgroundFillColorDefaultBrush",
+                    "LayerFillColorAltBrush",
                   ],
                 },
               },

--- a/src/components/NativeControlBadge.tsx
+++ b/src/components/NativeControlBadge.tsx
@@ -9,7 +9,7 @@ export function NativeControlBadge() {
     <Badge
       badgeColor={
         Platform.OS === 'windows'
-          ? PlatformColor('LayerFillColorAltBrush')
+          ? PlatformColor('SolidBackgroundFillColorSecondaryBrush')
           : colors.border
       }
       textColor={colors.text}

--- a/src/components/NativeControlBadge.tsx
+++ b/src/components/NativeControlBadge.tsx
@@ -9,7 +9,7 @@ export function NativeControlBadge() {
     <Badge
       badgeColor={
         Platform.OS === 'windows'
-          ? PlatformColor('CardBackgroundFillColorDefaultBrush')
+          ? PlatformColor('LayerFillColorAltBrush')
           : colors.border
       }
       textColor={colors.text}


### PR DESCRIPTION
## Description

### Why

Resolves #421

### What

Changes to a different brush that creates a bit more distinction between background color (but is ultimately still subtle).

## Screenshots

Chosen: `SolidBackgroundFillColorSecondaryBrush`
![image](https://github.com/microsoft/react-native-gallery/assets/26607885/a62b9f5b-c28b-466d-b2cb-23c74f64f25d)
![image](https://github.com/microsoft/react-native-gallery/assets/26607885/bee7b85d-f951-42b4-b4f8-b2c9847131d4)

For reference (not chosen): `LayerFillColorAltBrush`
![image](https://github.com/microsoft/react-native-gallery/assets/26607885/5e4f76ba-2f42-4c8d-bd00-9ac78e0aefda)
![image](https://github.com/microsoft/react-native-gallery/assets/26607885/50b28fab-4a0d-4fdc-b4c3-ec279efd06ee)
