### PR TITLE
Fix mis-merge of Network commit with badges commit

### DIFF
--- a/src/RNGalleryList.ts
+++ b/src/RNGalleryList.ts
@@ -171,12 +171,6 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     new: true,
   },
   {
-    key: 'Networking',
-    component: NetworkExamplePage,
-    textIcon: '\uE704',
-    type: 'Status and Info',
-  },
-  {
     key: 'Permissions',
     component: PermissionsExamplePage,
     textIcon: '\uED2C',


### PR DESCRIPTION
## Description

### Why

Bad merge of this:
https://github.com/microsoft/react-native-gallery/commit/158bf3ebb5fb9e1dea926dbca82cbac974e55bc6
with the preceding:
https://github.com/microsoft/react-native-gallery/commit/441af46fc3a81c389734757c5de704a800dc20e5

Produces a runtime error due to duplicate key.

```
 ERROR  Error: A navigator cannot contain multiple 'Screen' components with the same name (found duplicate screen named 'Networking')

This error is located at:
    in DrawerNavigator (created by MyDrawer)
    in MyDrawer (created by App)
    in EnsureSingleNavigator
    in BaseNavigationContainer
    in ThemeProvider
    in NavigationContainerInner (created by App)
    in App
    in RCTView (created by TextAncestorContext)
    in View (created by AppContainer)
    in RCTView (created by TextAncestorContext)
    in View (created by AppContainer)
    in AppContainer
    in rngallery(RootComponent), js engine: hermes
```

### What

Remove the duplicate entry.