### PR TITLE
Fix clipboard accessibility

### DIFF
--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -31,17 +31,22 @@ const CopyToClipboardButton = ({content}: CopyToClipboardButtonProps) => {
   const styles = createButtonStyles(isHovered, isPressing);
 
   const copyIcon = '\uE8C8';
+  const helpText = 'Copy to clipboard';
 
   return (
     <Pressable
-      tooltip={'Copy to clipboard'}
+      accessibilityRole="button"
+      accessibilityLabel={helpText}
+      tooltip={helpText}
       style={styles.background}
       onPress={() => Clipboard.setString(content)}
       onPressIn={() => setIsPressing(true)}
       onPressOut={() => setIsPressing(false)}
       onHoverIn={() => setIsHovered(true)}
       onHoverOut={() => setIsHovered(false)}>
-      <Text style={styles.text}>{copyIcon}</Text>
+      <Text accessible={false} style={styles.text}>
+        {copyIcon}
+      </Text>
     </Pressable>
   );
 };

--- a/src/components/Example.tsx
+++ b/src/components/Example.tsx
@@ -45,7 +45,11 @@ export function Example(props: {
       {props.code ? (
         <View style={styles.box}>
           <View style={styles.exampleContainer}>{props.children}</View>
-          <View style={styles.codeContainer}>
+          <View
+            style={styles.codeContainer}
+            accessible={true}
+            accessibilityRole="none"
+            accessibilityLabel="Source code">
             <Code>{props.code}</Code>
             <View style={{position: 'absolute', right: 12, top: 12}}>
               <CopyToClipboardButton content={props.code} />


### PR DESCRIPTION
## Description

### Why

Resolves #418

### What

Set correct accessibility properties so that has role of button and label.
Also set up grouping so that clipboards aren't peer items. Which better matches the (future) grouping behavior anyway.

## Screenshots

![image](https://github.com/microsoft/react-native-gallery/assets/26607885/be17bf9d-e0ce-4850-8291-22a6d0a73766)

