### PR TITLE
Add SVG sample page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+If this is your first time, below are some more detailed steps for getting your branch set up and submitting a PR. You can either do this with the command prompt or with a combination of the command prompt and VS Code.
+
+## Setting up your branch for changes
+For each bug or task you complete, it is recommended that you start with a fresh branch. If you have any lingering changes in your current branch that you want to save, go ahead and commit them. If you are just beginning, then you are good to go. On github, navigate to your repository which should be **forked** from Microsoft/react-native-windows. If you haven't already created a fork, follow the steps in [Github branch Setup](https://github.com/Microsoft/react-native-windows/wiki/Setup). Above the list of files is a dropdown that should say master. Use the dropdown to create a new branch and name is according to what you will be working on. (I.e. DropdownHighlight, CleanUpExamples, etc). Now you have created a new branch.
+
+**VS Code**: If you are using VS Code your current branch shows in the bottom left corner. You can click that and then select from the list to check out either a local or remote branch.
+
+**Git Command Line**: If you are using the command line, you will want to make sure you have your branch locally. It takes time for it to show up automatically, so you can make it show by running git remote update origin –prune in your command prompt from the root. Run git branch -a to see if your new branch shows up. Now you will want to check out your branch locally. You can do this with git checkout -b branch-name. Confirm you are now working out of the branch with git branch.
+
+## Make the fix
+Now that your branch is set up and ready for commits, go ahead and fix the bug you are working on or make some small change that you want to check in.
+
+## Verify your changes
+Manually test your fix, and ensure that all tests are in a good state.
+
+Note: If you update snapshots in a branch on the Gallery repo, it will update the timeZoneOffsetInSeconds property in the snapshots to -28800. Currently, this will fail in CI as the timezone when running the snapshot test in CI is different. You will need to manually set the timeZoneOffsetInSeconds value in your snapshots to '-0' after running the `updateSnapshots` command.
+
+## Commit your changes
+**VS Code**: In VS Code, click on Source Control from the left bar. In the list shown stage all of the files you want to submit by selecting them and clicking "+" ("Stage changes"). Add a short message in the textbox at the bottom on what is included in your change. The press "Commit".
+
+**Git Command Line**: To stage files using the command line, you need to run git add MyFileOne.tsx for each file. You can also look up how to add all files with changes under a directory. Next you will want to commit changes with git commit –m "This change updates the padding in the dropdown"
+
+You can commit multiple times until you are ready to make a pull request. You should keep the message short since it will not be used in the bug notes and is just for keeping track of the multiple commits in one pull request.
+
+## Creating a Pull Request
+**VS Code**: In VS Code click Push.
+
+**Git Command Line**: Run git push origin <branch_name>.
+
+This will push any staged files you have in your branch.
+
+Now go back to your fork on github. You should see a yellow bar at the top with your change and a button that says "Compare & Pull Request". Click that button.
+
+Click "Create Pull Request".
+
+Fill the description of your PR with an explanation of why you made this change, what the change is, and how you changed the repo. Then, if applicable include screenshots of errors/warnings you resolved, or changes to the UI you made. 
+
+A bunch of tests will automatically kick off to verify your PR. The tests marked as required must pass before a PR can be merged.
+
+Someone will also have to review your change before the change is allowed to be merged in. They may ask questions for more information or ask you to change things. Be sure to respond to their comments and push additional changes to the branch if they ask you to modify things before they sign off. Leave PRs open for at least 24 hours even if you have already received approval before the 24 hour mark; this ensure that all possible reviewers have had the opportunity to make comments.
+
+Now you are done! Celebrate! Thank you for your contribution!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,21 +45,9 @@ Now you are done! Celebrate! Thank you for your contribution!
 
 ![gallery_datepicker](https://user-images.githubusercontent.com/34109996/108123330-86734180-705a-11eb-8bea-409f017ab781.PNG)
 
-To add a sample page:
+To add a sample page you'll need to:
 
-1. Author your page as a standard RN component and export the component. See https://github.com/microsoft/RNGallery/tree/main/src/examples for existing sample pages
-2. Add an entry to the array in the [RNGalleryList](https://github.com/microsoft/RNGallery/blob/f592dac5969f054dad4837929d214c2fd63495a5/src/RNGalleryList.ts#L1)
+1. Author your page as a standard RN component that uses 'Page' and 'Example' components for structure. See [./src/examples/](https://github.com/microsoft/RNGallery/tree/main/src/examples) for existing sample pages
+2. Add an entry to the array in [RNGalleryList](https://github.com/microsoft/RNGallery/blob/f592dac5969f054dad4837929d214c2fd63495a5/src/RNGalleryList.ts#L1)
 
-```
-import {FooExamplePage} from './examples/FooExamplePage';
-
-export const RNGalleryList: Array<IRNGalleryExample> = [
-  ...
-  {
-    key: 'FooExamplePage',
-    component: FooExamplePage,
-  },
-];
-```
-
-It's that simple! The app will pick up your new sample page, add an item in the navigation draw for it, and navigate to your page when the user clicks on it. If you want a more detailed set of instructions on how to add a page visit [here](https://github.com/microsoft/react-native-gallery/wiki/Add-a-Component-Page).
+For more detailed instructions on how to add a page visit [here](https://github.com/microsoft/react-native-gallery/wiki/Add-a-Component-Page).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,26 @@ A bunch of tests will automatically kick off to verify your PR. The tests marked
 Someone will also have to review your change before the change is allowed to be merged in. They may ask questions for more information or ask you to change things. Be sure to respond to their comments and push additional changes to the branch if they ask you to modify things before they sign off. Leave PRs open for at least 24 hours even if you have already received approval before the 24 hour mark; this ensure that all possible reviewers have had the opportunity to make comments.
 
 Now you are done! Celebrate! Thank you for your contribution!
+
+# Adding Sample Pages
+
+![gallery_datepicker](https://user-images.githubusercontent.com/34109996/108123330-86734180-705a-11eb-8bea-409f017ab781.PNG)
+
+To add a sample page:
+
+1. Author your page as a standard RN component and export the component. See https://github.com/microsoft/RNGallery/tree/main/src/examples for existing sample pages
+2. Add an entry to the array in the [RNGalleryList](https://github.com/microsoft/RNGallery/blob/f592dac5969f054dad4837929d214c2fd63495a5/src/RNGalleryList.ts#L1)
+
+```
+import {FooExamplePage} from './examples/FooExamplePage';
+
+export const RNGalleryList: Array<IRNGalleryExample> = [
+  ...
+  {
+    key: 'FooExamplePage',
+    component: FooExamplePage,
+  },
+];
+```
+
+It's that simple! The app will pick up your new sample page, add an item in the navigation draw for it, and navigate to your page when the user clicks on it. If you want a more detailed set of instructions on how to add a page visit [here](https://github.com/microsoft/react-native-gallery/wiki/Add-a-Component-Page).

--- a/README.md
+++ b/README.md
@@ -29,26 +29,3 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 For addtional information about contributing to React Native Gallery visit [here](https://github.com/microsoft/react-native-gallery/wiki/Contributing-to-React-Native-Gallery).
-
-# Adding Sample Pages
-
-![gallery_datepicker](https://user-images.githubusercontent.com/34109996/108123330-86734180-705a-11eb-8bea-409f017ab781.PNG)
-
-To add a sample page:
-
-1. Author your page as a standard RN component and export the component. See https://github.com/microsoft/RNGallery/tree/main/src/examples for existing sample pages
-2. Add an entry to the array in the [RNGalleryList](https://github.com/microsoft/RNGallery/blob/f592dac5969f054dad4837929d214c2fd63495a5/src/RNGalleryList.ts#L1)
-
-```
-import {FooExamplePage} from './examples/FooExamplePage';
-
-export const RNGalleryList: Array<IRNGalleryExample> = [
-  ...
-  {
-    key: 'FooExamplePage',
-    component: FooExamplePage,
-  },
-];
-```
-
-It's that simple! The app will pick up your new sample page, add an item in the navigation draw for it, and navigate to your page when the user clicks on it. If you want a more detailed set of instructions on how to add a page visit [here](https://github.com/microsoft/react-native-gallery/wiki/Add-a-Component-Page).

--- a/__tests__/App-test.js
+++ b/__tests__/App-test.js
@@ -38,6 +38,7 @@ import {ExpanderExamplePage} from '../src/examples/ExpanderExamplePage';
 // Unable to import: {export * from './types'; SyntaxError: Unexpected token 'export'
 //import {RadioButtonsExamplePage} from '../src/examples/RadioButtonsExamplePage';
 import {NetworkExamplePage} from '../src/examples/NetworkExamplePage';
+import {SvgExamplePage} from '../src/examples/SvgExamplePage';
 import {View} from 'react-native';
 
 function Control() {
@@ -171,6 +172,11 @@ test('SensitiveInfo Example Page', () => {
 
 test('Slider Example Page', () => {
   const tree = create(<SliderExamplePage />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('SVG Example Page', () => {
+  const tree = create(<SvgExamplePage />).toJSON();
   expect(tree).toMatchSnapshot();
 });
 

--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -31949,6 +31949,1108 @@ exports[`ProgressView Example Page 1`] = `
 </View>
 `;
 
+exports[`SVG Example Page 1`] = `
+<View
+  style={
+    {
+      "backgroundColor": "#f9f9f9",
+      "flexDirection": "row",
+      "height": "100%",
+      "width": "100%",
+    }
+  }
+>
+  <View
+    accessibilityLabel="Navigation bar"
+    accessibilityRole="button"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    disabled={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "backgroundColor": {
+          "windowsbrush": [
+            "NavigationViewDefaultPaneBackground",
+          ],
+        },
+        "height": "100%",
+        "paddingBottom": 20,
+        "width": 48,
+      }
+    }
+  >
+    <View>
+      <View
+        accessibilityLabel="Navigation bar hamburger icon"
+        accessibilityRole="button"
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "borderRadius": 3,
+            "height": 34,
+            "justifyContent": "center",
+            "margin": 5,
+            "width": 38,
+          }
+        }
+        tooltip="Expand Menu"
+      >
+        <Text
+          style={
+            {
+              "color": {
+                "windowsbrush": [
+                  "TextControlForeground",
+                ],
+              },
+              "fontFamily": "Segoe MDL2 Assets",
+              "fontSize": 16,
+            }
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "alignSelf": "stretch",
+          "borderColor": {
+            "windowsbrush": [
+              "SurfaceStrokeColorFlyoutBrush",
+            ],
+          },
+          "borderLeftWidth": 1,
+          "borderTopLeftRadius": 8,
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "height": "100%",
+        },
+        {
+          "paddingLeft": 36,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "marginBottom": 10,
+          "marginTop": 44,
+          "paddingRight": 20,
+        }
+      }
+    >
+      <Text
+        accessibilityRole="header"
+        accessible={true}
+        style={
+          {
+            "fontSize": 28,
+            "fontWeight": "600",
+          }
+        }
+      >
+        SVG
+      </Text>
+      <View>
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "borderRadius": 3,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "margin": 2,
+                "paddingBottom": 5,
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 5,
+              },
+              {
+                "backgroundColor": {
+                  "windowsbrush": [
+                    "AccentFillColorDefaultBrush",
+                  ],
+                },
+              },
+            ]
+          }
+          tooltip="This component is not a part of React Native core. The package for this component must be explicitly added in order to have access to this component in a React Native project."
+        >
+          <Text
+            style={
+              [
+                {
+                  "fontSize": 15,
+                  "fontWeight": "400",
+                  "paddingRight": 4,
+                },
+                {
+                  "color": {
+                    "windowsbrush": [
+                      "TextOnAccentFillColorPrimaryBrush",
+                    ],
+                  },
+                },
+              ]
+            }
+          >
+            Community Module
+          </Text>
+          <XamlControl
+            foreground={
+              {
+                "windowsbrush": [
+                  "TextOnAccentFillColorPrimaryBrush",
+                ],
+              }
+            }
+            symbol={57637}
+            type="Windows.UI.Xaml.Controls.SymbolIcon"
+          />
+        </View>
+      </View>
+    </View>
+    <Text
+      style={
+        [
+          {
+            "paddingRight": 20,
+          },
+          {
+            "color": "rgb(28, 28, 30)",
+          },
+        ]
+      }
+    >
+      A component which renders vector graphics.
+    </Text>
+    <RCTScrollView
+      style={
+        {
+          "paddingRight": 20,
+        }
+      }
+    >
+      <View>
+        <View>
+          <Text
+            accessibilityRole="header"
+            style={
+              {
+                "color": "rgb(28, 28, 30)",
+                "fontSize": 20,
+                "marginBottom": 10,
+                "marginTop": 30,
+              }
+            }
+          >
+            A simple Image from web source.
+          </Text>
+          <View
+            style={
+              {
+                "borderColor": "rgb(216, 216, 216)",
+                "borderRadius": 8,
+                "borderWidth": 1,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "SolidBackgroundFillColorSecondaryBrush",
+                    ],
+                  },
+                  "padding": 15,
+                }
+              }
+            >
+              <RNSVGSvgView
+                align="xMidYMid"
+                bbHeight="200px"
+                bbWidth="200px"
+                focusable={false}
+                height="200px"
+                meetOrSlice={0}
+                minX={0}
+                minY={0}
+                style={
+                  [
+                    {
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                    },
+                    {
+                      "flex": 0,
+                      "height": 200,
+                      "width": 200,
+                    },
+                  ]
+                }
+                vbHeight={100}
+                vbWidth={100}
+                width="200px"
+              >
+                <RNSVGGroup
+                  fill={
+                    {
+                      "payload": 4278190080,
+                      "type": 0,
+                    }
+                  }
+                >
+                  <RNSVGCircle
+                    cx="50"
+                    cy="50"
+                    fill={
+                      {
+                        "payload": 4278222848,
+                        "type": 0,
+                      }
+                    }
+                    propList={
+                      [
+                        "fill",
+                        "stroke",
+                        "strokeWidth",
+                      ]
+                    }
+                    r="45"
+                    stroke={
+                      {
+                        "payload": 4278190335,
+                        "type": 0,
+                      }
+                    }
+                    strokeWidth="2.5"
+                  />
+                  <RNSVGRect
+                    fill={
+                      {
+                        "payload": 4294967040,
+                        "type": 0,
+                      }
+                    }
+                    height="70"
+                    propList={
+                      [
+                        "fill",
+                        "stroke",
+                        "strokeWidth",
+                      ]
+                    }
+                    stroke={
+                      {
+                        "payload": 4294901760,
+                        "type": 0,
+                      }
+                    }
+                    strokeWidth="2"
+                    width="70"
+                    x="15"
+                    y="15"
+                  />
+                </RNSVGGroup>
+              </RNSVGSvgView>
+            </View>
+            <View
+              accessibilityLabel="Source code"
+              accessibilityRole="none"
+              accessible={true}
+              style={
+                {
+                  "backgroundColor": {
+                    "windowsbrush": [
+                      "CardBackgroundFillColorDefaultBrush",
+                    ],
+                  },
+                  "borderColor": "rgb(216, 216, 216)",
+                  "borderTopWidth": 1,
+                  "borderWidth": 0,
+                  "padding": 12,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "backgroundColor": "transparent",
+                    "flexGrow": 1,
+                    "padding": 5,
+                  }
+                }
+              >
+                <Text
+                  selectable={true}
+                  style={
+                    {
+                      "color": "#000000",
+                      "fontFamily": "Consolas",
+                    }
+                  }
+                >
+                  <Text>
+                    &lt;Svg height=
+                  </Text>
+                  <Text
+                    style={
+                      {
+                        "color": "#0000FF",
+                      }
+                    }
+                  >
+                    <Text>
+                      "200px"
+                    </Text>
+                  </Text>
+                  <Text>
+                     width=
+                  </Text>
+                  <Text
+                    style={
+                      {
+                        "color": "#0000FF",
+                      }
+                    }
+                  >
+                    <Text>
+                      "200px"
+                    </Text>
+                  </Text>
+                  <Text>
+                     viewBox=
+                  </Text>
+                  <Text
+                    style={
+                      {
+                        "color": "#0000FF",
+                      }
+                    }
+                  >
+                    <Text>
+                      "0 0 100 100"
+                    </Text>
+                  </Text>
+                  <Text>
+                    &gt;
+  
+                  </Text>
+                  <Text
+                    style={{}}
+                  >
+                    <Text
+                      style={
+                        {
+                          "color": "#0000FF",
+                        }
+                      }
+                    >
+                      <Text>
+                        &lt;
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#A31515",
+                          }
+                        }
+                      >
+                        <Text>
+                          Circle
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+    
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          cx
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "50"
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+    
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          cy
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "50"
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+    
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          r
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "45"
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+    
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          stroke
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "blue"
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+    
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          strokeWidth
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "2.5"
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+    
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          fill
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "green"
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+  /&gt;
+                      </Text>
+                    </Text>
+                  </Text>
+                  <Text>
+                    
+  
+                  </Text>
+                  <Text
+                    style={{}}
+                  >
+                    <Text
+                      style={
+                        {
+                          "color": "#0000FF",
+                        }
+                      }
+                    >
+                      <Text>
+                        &lt;
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#A31515",
+                          }
+                        }
+                      >
+                        <Text>
+                          Rect
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+    
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          x
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "15"
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+    
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          y
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "15"
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+    
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          width
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "70"
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+    
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          height
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "70"
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+    
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          stroke
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "red"
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+    
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          strokeWidth
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "2"
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+    
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#000000",
+                          }
+                        }
+                      >
+                        <Text>
+                          fill
+                        </Text>
+                      </Text>
+                      <Text>
+                        =
+                      </Text>
+                      <Text
+                        style={
+                          {
+                            "color": "#0000FF",
+                          }
+                        }
+                      >
+                        <Text>
+                          "yellow"
+                        </Text>
+                      </Text>
+                      <Text>
+                        
+  /&gt;
+                      </Text>
+                    </Text>
+                  </Text>
+                  <Text>
+                    
+&lt;/Svg&gt;
+                  </Text>
+                </Text>
+              </View>
+              <View
+                style={
+                  {
+                    "position": "absolute",
+                    "right": 12,
+                    "top": 12,
+                  }
+                }
+              >
+                <View
+                  accessibilityLabel="Copy to clipboard"
+                  accessibilityRole="button"
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  disabled={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    {
+                      "backgroundColor": {
+                        "windowsbrush": [
+                          "ControlFillColorDefaultBrush",
+                        ],
+                      },
+                      "borderColor": {
+                        "windowsbrush": [
+                          "ControlStrokeColorDefaultBrush",
+                        ],
+                      },
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "padding": 6,
+                    }
+                  }
+                  tooltip="Copy to clipboard"
+                >
+                  <Text
+                    accessible={false}
+                    style={
+                      {
+                        "color": {
+                          "windowsbrush": [
+                            "TextControlForeground",
+                          ],
+                        },
+                        "fontFamily": "Segoe MDL2 Assets",
+                        "fontSize": 16,
+                      }
+                    }
+                  >
+                    
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            {
+              "flexDirection": "column",
+              "marginRight": 90,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "alignItems": "flex-start",
+                  "marginBottom": 10,
+                  "marginRight": 30,
+                  "marginTop": 30,
+                }
+              }
+            >
+              <Text
+                accessibilityRole="header"
+                style={
+                  {
+                    "color": "rgb(28, 28, 30)",
+                    "fontSize": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                View page code on Github
+              </Text>
+              <XamlControl
+                content={
+                  {
+                    "string": "Source Code",
+                  }
+                }
+                navigateUri="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/SvgExamplePage.tsx"
+                type="Windows.UI.Xaml.Controls.HyperlinkButton"
+              />
+            </View>
+            <View
+              style={
+                {
+                  "alignItems": "flex-start",
+                  "marginBottom": 10,
+                  "marginRight": 30,
+                  "marginTop": 30,
+                }
+              }
+            >
+              <Text
+                accessibilityRole="header"
+                style={
+                  {
+                    "color": "rgb(28, 28, 30)",
+                    "fontSize": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                Feedback
+              </Text>
+              <XamlControl
+                content={
+                  {
+                    "string": "Send feedback about this page",
+                  }
+                }
+                navigateUri="https://github.com/microsoft/react-native-gallery/issues/new"
+                type="Windows.UI.Xaml.Controls.HyperlinkButton"
+              />
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "alignItems": "flex-start",
+                "marginBottom": 10,
+                "marginRight": 30,
+                "marginTop": 30,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="header"
+              style={
+                {
+                  "color": "rgb(28, 28, 30)",
+                  "fontSize": 20,
+                  "marginBottom": 10,
+                }
+              }
+            >
+              Documentation
+            </Text>
+            <XamlControl
+              content={
+                {
+                  "string": "Svg",
+                }
+              }
+              navigateUri="https://github.com/software-mansion/react-native-svg"
+              type="Windows.UI.Xaml.Controls.HyperlinkButton"
+            />
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+  </View>
+</View>
+`;
+
 exports[`ScrollView Example Page 1`] = `
 <View
   style={

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-native-safe-area-context": "^4.2.4",
     "react-native-screens": "^2.9.0",
     "react-native-sensitive-info": "6.0.0-alpha.9",
+    "react-native-svg": "^15.2.0",
     "react-native-track-player": "JaneaSystems/react-native-track-player#windows_cpp2",
     "react-native-tts": "ak1394/react-native-tts",
     "react-native-webview": "^13.2.2",

--- a/patches/react-native-svg+15.2.0.patch
+++ b/patches/react-native-svg+15.2.0.patch
@@ -1,0 +1,28 @@
+diff --git a/node_modules/react-native-svg/windows/RNSVG/RNSVG.vcxproj b/node_modules/react-native-svg/windows/RNSVG/RNSVG.vcxproj
+index 0fdeca0..9ab5fb9 100644
+--- a/node_modules/react-native-svg/windows/RNSVG/RNSVG.vcxproj
++++ b/node_modules/react-native-svg/windows/RNSVG/RNSVG.vcxproj
+@@ -26,12 +26,10 @@
+     <AppContainerApplication>true</AppContainerApplication>
+     <ApplicationType>Windows Store</ApplicationType>
+     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+-    <WindowsTargetPlatformMinVersion>10.0.22621.0</WindowsTargetPlatformMinVersion>
+   </PropertyGroup>
+   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props')" />
+   <PropertyGroup Label="Fallback Windows SDK Versions">
+-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'=='' Or $([MSBuild]::VersionLessThan('$(WindowsTargetPlatformVersion)', '10.0.18362.0'))">10.0.18362.0</WindowsTargetPlatformVersion>
++    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'==''">10.0.18362.0</WindowsTargetPlatformVersion>
+     <WindowsTargetPlatformMinVersion Condition=" '$(WindowsTargetPlatformMinVersion)' == '' ">10.0.16299.0</WindowsTargetPlatformMinVersion>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+@@ -122,6 +120,9 @@
+     <ClCompile>
+       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+     </ClCompile>
++    <Link>
++      <AdditionalDependencies>dxguid.lib;WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>
++    </Link>
+   </ItemDefinitionGroup>
+   <ItemGroup>
+     <ClInclude Include="BrushView.h" />

--- a/src/RNGalleryList.ts
+++ b/src/RNGalleryList.ts
@@ -40,6 +40,7 @@ import {ExpanderExamplePage} from './examples/ExpanderExamplePage';
 import {VirtualizedListExamplePage} from './examples/VirtualizedListExamplePage';
 import {LinearGradientExamplePage} from './examples/LinearGradientExamplePage';
 import {NetworkExamplePage} from './examples/NetworkExamplePage';
+import {SvgExamplePage} from './examples/SvgExamplePage';
 
 // https://github.com/microsoft/WinUI-Gallery/blob/c8f04135579c08c9a80711dcad7247f259891c79/WinUIGallery/DataModel/ControlInfoData.json#L803
 let RNGalleryCategories = [
@@ -261,6 +262,14 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     subtitle:
       'A button that can be switched between two states like a CheckBox.',
     type: 'Basic Input',
+  },
+  {
+    key: 'Svg',
+    component: SvgExamplePage,
+    textIcon: '\uE734',
+    subtitle: 'Rendering of vector graphics.',
+    type: 'Media',
+    new: true,
   },
   {
     key: 'Text',

--- a/src/examples/RadioButtonsExamplePage.tsx
+++ b/src/examples/RadioButtonsExamplePage.tsx
@@ -32,7 +32,7 @@ export const RadioButtonsExamplePage: React.FunctionComponent<{}> = () => {
       title="Radio Buttons"
       description="Use radio buttons to let a user choose between mutually exclusive, related options."
       componentType="Community"
-      pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/LinearGradientExamplePage.tsx"
+      pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/RadioButtonsExamplePage.tsx"
       documentation={[
         {
           label: 'Radio Buttons Group',

--- a/src/examples/SvgExamplePage.tsx
+++ b/src/examples/SvgExamplePage.tsx
@@ -1,0 +1,63 @@
+'use strict';
+import React from 'react';
+import {Example} from '../components/Example';
+import {Page} from '../components/Page';
+import Svg, {Circle, Rect} from 'react-native-svg';
+
+export const SvgExamplePage: React.FunctionComponent<{}> = () => {
+  const example1jsx = `<Svg height="200px" width="200px" viewBox="0 0 100 100">
+  <Circle
+    cx="50"
+    cy="50"
+    r="45"
+    stroke="blue"
+    strokeWidth="2.5"
+    fill="green"
+  />
+  <Rect
+    x="15"
+    y="15"
+    width="70"
+    height="70"
+    stroke="red"
+    strokeWidth="2"
+    fill="yellow"
+  />
+</Svg>`;
+
+  return (
+    <Page
+      title="SVG"
+      description="A component which renders vector graphics."
+      componentType="Community"
+      pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/SvgExamplePage.tsx"
+      documentation={[
+        {
+          label: 'Svg',
+          url: 'https://github.com/software-mansion/react-native-svg',
+        },
+      ]}>
+      <Example title="A simple Image from web source." code={example1jsx}>
+        <Svg height="200px" width="200px" viewBox="0 0 100 100">
+          <Circle
+            cx="50"
+            cy="50"
+            r="45"
+            stroke="blue"
+            strokeWidth="2.5"
+            fill="green"
+          />
+          <Rect
+            x="15"
+            y="15"
+            width="70"
+            height="70"
+            stroke="red"
+            strokeWidth="2"
+            fill="yellow"
+          />
+        </Svg>
+      </Example>
+    </Page>
+  );
+};

--- a/windows/rngallery.sln
+++ b/windows/rngallery.sln
@@ -71,6 +71,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactNativeWindowsHello", "
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RNLinearGradient", "..\node_modules\react-native-linear-gradient\windows\RNLinearGradient\RNLinearGradient\RNLinearGradient.vcxproj", "{193DF456-3F97-4CC1-A7D4-809857CC064E}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RNSVG", "..\node_modules\react-native-svg\windows\RNSVG\RNSVG.vcxproj", "{7ACF84EC-EFBA-4043-8E14-40B159508902}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -389,6 +391,18 @@ Global
 		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Release|x64.Build.0 = Release|x64
 		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Release|x86.ActiveCfg = Release|Win32
 		{193DF456-3F97-4CC1-A7D4-809857CC064E}.Release|x86.Build.0 = Release|Win32
+		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Debug|ARM64.Build.0 = Debug|ARM64
+		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Debug|x64.ActiveCfg = Debug|x64
+		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Debug|x64.Build.0 = Debug|x64
+		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Debug|x86.ActiveCfg = Debug|Win32
+		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Debug|x86.Build.0 = Debug|Win32
+		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Release|ARM64.ActiveCfg = Release|ARM64
+		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Release|ARM64.Build.0 = Release|ARM64
+		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Release|x64.ActiveCfg = Release|x64
+		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Release|x64.Build.0 = Release|x64
+		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Release|x86.ActiveCfg = Release|Win32
+		{7ACF84EC-EFBA-4043-8E14-40B159508902}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/windows/rngallery/AutolinkedNativeModules.g.cpp
+++ b/windows/rngallery/AutolinkedNativeModules.g.cpp
@@ -45,6 +45,9 @@
 // Includes from react-native-sensitive-info
 #include <winrt/RNSensitiveInfoCPP.h>
 
+// Includes from react-native-svg
+#include <winrt/RNSVG.h>
+
 // Includes from react-native-track-player
 #include <winrt/RNTrackPlayer.h>
 
@@ -93,6 +96,8 @@ void RegisterAutolinkedNativeModulePackages(winrt::Windows::Foundation::Collecti
     packageProviders.Append(winrt::RNPrint::ReactPackageProvider());
     // IReactPackageProviders from react-native-sensitive-info
     packageProviders.Append(winrt::RNSensitiveInfoCPP::ReactPackageProvider());
+    // IReactPackageProviders from react-native-svg
+    packageProviders.Append(winrt::RNSVG::ReactPackageProvider());
     // IReactPackageProviders from react-native-track-player
     packageProviders.Append(winrt::RNTrackPlayer::ReactPackageProvider());
     // IReactPackageProviders from react-native-tts

--- a/windows/rngallery/AutolinkedNativeModules.g.targets
+++ b/windows/rngallery/AutolinkedNativeModules.g.targets
@@ -58,6 +58,10 @@
     <ProjectReference Include="$(ProjectDir)..\..\node_modules\react-native-sensitive-info\windows\RNSensitiveInfoCPP\RNSensitiveInfoCPP.vcxproj">
       <Project>{471024f1-cd6d-4f1e-a6c7-0037152c850e}</Project>
     </ProjectReference>
+    <!-- Projects from react-native-svg -->
+    <ProjectReference Include="$(ProjectDir)..\..\node_modules\react-native-svg\windows\RNSVG\RNSVG.vcxproj">
+      <Project>{7acf84ec-efba-4043-8e14-40b159508902}</Project>
+    </ProjectReference>
     <!-- Projects from react-native-track-player -->
     <ProjectReference Include="$(ProjectDir)..\..\node_modules\react-native-track-player\windows\RNTrackPlayer\RNTrackPlayer.vcxproj">
       <Project>{CC51D49E-7FAB-42D2-825D-5E93AC57262C}</Project>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5007,6 +5007,11 @@ bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -5490,6 +5495,30 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
+css-tree@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
+  integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
+  dependencies:
+    mdn-data "2.0.14"
+    source-map "^0.6.1"
+
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
+
 csstype@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.3.tgz#2b410bbeba38ba9633353aff34b05d9755d065f8"
@@ -5666,6 +5695,36 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -5731,6 +5790,11 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+entities@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 envinfo@^7.10.0:
   version "7.11.0"
@@ -8064,6 +8128,11 @@ marky@^1.2.2:
   resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.5.tgz#55796b688cbd72390d2d399eaaf1832c9413e3c0"
   integrity sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==
 
+mdn-data@2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
+  integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
+
 mem@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
@@ -9228,6 +9297,13 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
+
 nullthrows@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
@@ -9871,6 +9947,11 @@ react-native-print@0.8.0:
   resolved "https://registry.yarnpkg.com/react-native-print/-/react-native-print-0.8.0.tgz#9d200812ff2462c0d2421776dcab378e544a52fc"
   integrity sha512-eldQMPw5YjhHLckIvG2EodLvADjjk42k//CMVqQJ7wJHpm6gk0znlZmSC/oz2M46J74dzLLVcq20xgt5lQTP6w==
 
+react-native-radio-buttons-group@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-radio-buttons-group/-/react-native-radio-buttons-group-3.1.0.tgz#b19d383fc2dece17eba1ce37b9f357c47431aded"
+  integrity sha512-DiNM1yI6WfRygUZ+Z/bsjggyLypXsxRNXPNYpPHXSEVbRD6uF5Aei+HMIwyeRbfMKPtHwLq7cGsmUDV01i+rOQ==
+
 react-native-reanimated@^1.10.0:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-1.13.4.tgz#f57c65e80ab5d2f60bf7dd21716c0bad8108b84e"
@@ -9892,6 +9973,14 @@ react-native-sensitive-info@6.0.0-alpha.9:
   version "6.0.0-alpha.9"
   resolved "https://registry.yarnpkg.com/react-native-sensitive-info/-/react-native-sensitive-info-6.0.0-alpha.9.tgz#b488fab715d36efdf80b377a21545cfe888ab8d2"
   integrity sha512-W2R1gUHgBAmy+wVl0BvA7s01SqqTitnG4Sdj2zmck0OS5a54kq+pTnXRqDljMa2NQs4Mue2IHyvd+Tf0X1ZL6Q==
+
+react-native-svg@^15.2.0:
+  version "15.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.2.0.tgz#9561a6b3bd6b44689f437ba13182afee33bd5557"
+  integrity sha512-R0E6IhcJfVLsL0lRmnUSm72QO+mTqcAOM5Jb8FVGxJqX3NfJMlMP0YyvcajZiaRR8CqQUpEoqrY25eyZb006kw==
+  dependencies:
+    css-select "^5.1.0"
+    css-tree "^1.1.3"
 
 react-native-track-player@JaneaSystems/react-native-track-player#windows_cpp2:
   version "1.2.5"


### PR DESCRIPTION
## Description

### Why

Resolves #443 
Related #440 

### What

- New SVG sample page!
- Moved some info from wiki and readme to a proper CONTRIBUTING.md file
- Updated readme and contribution guide to streamline "new sample page" steps (including updating the wiki, which they link to)
- Fixed an incorrect link from #411 

## Screenshots

![image](https://github.com/microsoft/react-native-gallery/assets/26607885/2a106a08-e985-4b85-a856-2de7a4893575)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/444)