### PR TITLE
Add category pages

### DIFF
--- a/src/ComponentListPage.tsx
+++ b/src/ComponentListPage.tsx
@@ -1,0 +1,138 @@
+'use strict';
+import {StyleSheet, View, Text, ScrollView, PlatformColor} from 'react-native';
+import React from 'react';
+import {useIsFocused} from '@react-navigation/native';
+import RNGalleryList, {RNGalleryCategories} from './RNGalleryList';
+import {ScreenWrapper} from './components/ScreenWrapper';
+import {HomeComponentTile} from './components/ControlItem';
+
+const createStyles = () =>
+  StyleSheet.create({
+    container: {
+      padding: 10,
+      paddingBottom: 40,
+      paddingLeft: 36,
+      alignSelf: 'stretch',
+      height: '100%',
+      alignContent: 'flex-start',
+    },
+    controlItems: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: 12,
+    },
+    title: {
+      marginTop: 30,
+      marginBottom: 10,
+      fontSize: 20,
+    },
+    heading: {
+      marginTop: 30,
+      marginBottom: 10,
+      fontSize: 20,
+      fontWeight: '600',
+      color: PlatformColor('TextFillColorPrimaryBrush'),
+    },
+    homeContainer: {
+      alignItems: 'flex-start',
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+    },
+  });
+
+type ListOfComponentsProps = {
+  navigation: any;
+  heading: string;
+  items: any[];
+};
+const ListOfComponents = ({
+  navigation,
+  heading,
+  items,
+}: ListOfComponentsProps) => {
+  const styles = createStyles();
+  return (
+    <View
+      accessibilityLabel={heading + 'components'}
+      accessible={true}
+      accessibilityRole="none">
+      <Text accessibilityRole="header" style={styles.heading}>
+        {heading}
+      </Text>
+      <View style={styles.controlItems}>
+        {items.map((item) => (
+          <HomeComponentTile
+            key={item.key}
+            item={item}
+            navigation={navigation}
+          />
+        ))}
+      </View>
+    </View>
+  );
+};
+
+type GroupedListOfAllComponentsProps = {
+  route: any;
+  navigation: any;
+};
+const GroupedListOfAllComponents = ({
+  route,
+  navigation,
+}: GroupedListOfAllComponentsProps) => {
+  return (
+    <View>
+      {RNGalleryCategories.map((category) => (
+        <ListOfComponents
+          key={category.label}
+          navigation={navigation}
+          heading={category.label}
+          items={RNGalleryList.filter((item) => item.type === category.label)}
+        />
+      ))}
+    </View>
+  );
+};
+
+type ComponentListPageProps = {
+  route: any;
+  navigation: any;
+};
+const ComponentListPage = ({route, navigation}: ComponentListPageProps) => {
+  const styles = createStyles();
+  const isScreenFocused = useIsFocused();
+
+  const category = route.params?.category;
+
+  return isScreenFocused ? (
+    <View>
+      <ScreenWrapper doNotInset={true}>
+        <ScrollView>
+          {category !== undefined ? (
+            <View style={styles.container}>
+              <ListOfComponents
+                navigation={navigation}
+                heading={category}
+                items={RNGalleryList.filter((item) => item.type === category)}
+              />
+            </View>
+          ) : (
+            <View style={styles.container}>
+              <Text accessibilityRole={'header'} style={styles.title}>
+                All samples
+              </Text>
+              <GroupedListOfAllComponents
+                route={route}
+                navigation={navigation}
+              />
+            </View>
+          )}
+        </ScrollView>
+      </ScreenWrapper>
+    </View>
+  ) : (
+    <View />
+  );
+};
+
+export {ComponentListPage, ListOfComponents};

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -5,26 +5,18 @@ import {
   Text,
   ScrollView,
   Image,
-  PlatformColor,
   useColorScheme,
 } from 'react-native';
 import React from 'react';
 import {useTheme, useIsFocused} from '@react-navigation/native';
-import RNGalleryList, {RNGalleryCategories} from './RNGalleryList';
+import RNGalleryList from './RNGalleryList';
 import {ScreenWrapper} from './components/ScreenWrapper';
-import {HomeComponentTile} from './components/ControlItem';
 import {TileGallery} from './components/TileGallery';
+import {ListOfComponents} from './ComponentListPage';
 import LinearGradient from 'react-native-linear-gradient';
 
 const createStyles = () =>
   StyleSheet.create({
-    heading: {
-      marginTop: 30,
-      marginBottom: 10,
-      fontSize: 20,
-      fontWeight: '600',
-      color: PlatformColor('TextFillColorPrimaryBrush'),
-    },
     container: {
       padding: 10,
       paddingBottom: 40,
@@ -36,19 +28,9 @@ const createStyles = () =>
     scrollView: {
       paddingRight: 20,
     },
-    homeContainer: {
-      alignItems: 'flex-start',
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-    },
     icon: {
       fontFamily: 'Segoe MDL2 Assets',
       fontSize: 16,
-    },
-    controlItems: {
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      gap: 12,
     },
     heroGradient: {
       position: 'absolute',
@@ -127,68 +109,6 @@ const PageTitle = () => {
   );
 };
 
-const HomeContainer = (props: {heading: string; children: React.ReactNode}) => {
-  const {colors} = useTheme();
-  const styles = createStyles(colors);
-  return (
-    <View
-      accessibilityLabel={props.heading + 'components'}
-      accessible={true}
-      accessibilityRole="none">
-      <Text accessibilityRole="header" style={styles.heading}>
-        {props.heading}
-      </Text>
-      <View style={styles.homeContainer}>{props.children}</View>
-    </View>
-  );
-};
-
-const RenderHomeComponentTiles = (indicies: number[], navigation) => {
-  const {colors} = useTheme();
-  const styles = createStyles(colors);
-
-  var homeComponentTiles = [];
-  for (var i = 0; i < indicies.length; i++) {
-    let index = indicies[i];
-    let item = RNGalleryList[index];
-    homeComponentTiles.push(
-      <HomeComponentTile
-        key={indicies[i]}
-        item={item}
-        navigation={navigation}
-      />,
-    );
-  }
-
-  return <View style={styles.controlItems}>{homeComponentTiles}</View>;
-};
-
-const RenderPageContent = ({navigation}) => {
-  let categoryMap = new Map();
-  RNGalleryCategories.forEach((category) => {
-    categoryMap.set(category.label, []);
-  });
-
-  RNGalleryList.forEach((item, index) => {
-    let category = item.type;
-    let categoryList = categoryMap.get(category);
-    categoryList?.push(index);
-  });
-
-  return (
-    <ScrollView>
-      {RNGalleryCategories.map((category) => (
-        <HomeContainer key={category.label} heading={category.label}>
-          {RenderHomeComponentTiles(
-            categoryMap.get(category.label),
-            navigation,
-          )}
-        </HomeContainer>
-      ))}
-    </ScrollView>
-  );
-};
-
 export const HomePage: React.FunctionComponent<{}> = ({navigation}) => {
   const {colors} = useTheme();
   const styles = createStyles(colors);
@@ -200,7 +120,16 @@ export const HomePage: React.FunctionComponent<{}> = ({navigation}) => {
         <ScrollView>
           <PageTitle />
           <View style={styles.container}>
-            <RenderPageContent navigation={navigation} />
+            <ListOfComponents
+              heading="Recently added samples"
+              items={RNGalleryList.filter((item) => item.new)}
+              navigation={navigation}
+            />
+            <ListOfComponents
+              heading="Recently updated samples"
+              items={RNGalleryList.filter((item) => item.recentlyUpdated)}
+              navigation={navigation}
+            />
           </View>
         </ScrollView>
       </ScreenWrapper>

--- a/src/RNGalleryList.ts
+++ b/src/RNGalleryList.ts
@@ -110,6 +110,7 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     component: ClipboardExamplePage,
     textIcon: '\uE8C8',
     imageIcon: require('../assets/ControlImages/Clipboard.png'),
+    subtitle: 'Copy and paste to and from the system Clipboard.',
     type: 'System',
     new: true,
   },
@@ -147,6 +148,8 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     component: FlatListExamplePage,
     textIcon: '\uE8A4',
     imageIcon: require('../assets/ControlImages/ListView.png'),
+    subtitle:
+      'A performant interface for rendering basic, flat lists, supporting the most handy features.',
     type: 'Collections',
   },
   {
@@ -170,6 +173,7 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     component: LinearGradientExamplePage,
     textIcon: '\uE790',
     type: 'Media',
+    subtitle: 'Render a horizontal or vertical color gradient.',
     new: true,
   },
   {
@@ -177,6 +181,7 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     component: NetworkExamplePage,
     textIcon: '\uE704',
     type: 'Status and Info',
+    subtitle: 'Load resources from a remote URL.',
     new: true,
   },
   {
@@ -198,6 +203,7 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     component: PopupExamplePage,
     textIcon: '\uE75A',
     imageIcon: require('../assets/ControlImages/Flyout.png'),
+    subtitle: 'Displays content on top of existing content.',
     type: 'Dialogs & flyouts',
   },
   {
@@ -205,6 +211,8 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     component: PressableExamplePage,
     textIcon: '\uE815',
     imageIcon: require('../assets/ControlImages/Button.png'),
+    subtitle:
+      'A component that can detect various stages of press interactions on any of its defined children.',
     type: 'Basic Input',
   },
   {
@@ -314,18 +322,22 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     key: 'TouchableHighlight',
     component: TouchableHighlightExamplePage,
     textIcon: '\uEDA4',
+    subtitle: 'A legacy wrapper for making views respond to touches.',
     type: 'Legacy',
   },
   {
     key: 'TouchableOpacity',
     component: TouchableOpacityExamplePage,
     textIcon: '\uEDA4',
+    subtitle: 'A legacy wrapper for making views respond to touches.',
     type: 'Legacy',
   },
   {
     key: 'TouchableWithoutFeedback',
     component: TouchableWithoutFeedbackExamplePage,
     textIcon: '\uEDA4',
+    subtitle:
+      'A legacy wrapper for making views respond to touches without any visual feedback (not recommended).',
     type: 'Legacy',
   },
   {
@@ -340,6 +352,7 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     component: ViewExamplePage,
     textIcon: '\uECA5',
     imageIcon: require('../assets/ControlImages/Canvas.png'),
+    subtitle: 'The most fundamental component for building a UI',
     type: 'Layout',
   },
   {
@@ -362,12 +375,15 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     component: VirtualizedListExamplePage,
     textIcon: '\uE8A4',
     imageIcon: require('../assets/ControlImages/ListView.png'),
+    subtitle:
+      'The base implementation for FlatList and SectionList, which can be used as alternative if you need more flexibility.',
     type: 'Collections',
   },
   {
     key: 'Xaml',
     component: XamlExamplePage,
     textIcon: '\uE70F',
+    subtitle: 'Directly access any native XAML control.',
     type: 'Layout',
     recentlyUpdated: true,
   },

--- a/src/RNGalleryList.ts
+++ b/src/RNGalleryList.ts
@@ -3,6 +3,7 @@ import React from 'react';
 import type {ImageSourcePropType} from 'react-native';
 import {HomePage} from './HomePage';
 import {SettingsPage} from './SettingsPage';
+import {ComponentListPage} from './ComponentListPage';
 import {ButtonExamplePage} from './examples/ButtonExamplePage';
 import {CheckBoxExamplePage} from './examples/CheckBoxExamplePage';
 import {ClipboardExamplePage} from './examples/ClipboardExamplePage';
@@ -80,6 +81,12 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     key: 'Settings',
     component: SettingsPage,
     textIcon: '\uE713',
+    type: '',
+  },
+  {
+    key: 'All samples',
+    component: ComponentListPage,
+    textIcon: '\uE71D',
     type: '',
   },
   {
@@ -370,6 +377,12 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     textIcon: '\uE78A',
     type: 'Media',
   },
+  ...RNGalleryCategories.map((category) => ({
+    key: `Category: ${category.label}`,
+    component: ComponentListPage,
+    textIcon: category.icon,
+    type: '',
+  })),
 ];
 
 export default RNGalleryList;

--- a/windows/rngallery/packages.lock.json
+++ b/windows/rngallery/packages.lock.json
@@ -75,6 +75,13 @@
           "fmt": "[1.0.0, )"
         }
       },
+      "lottiereactnative": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.ReactNative": "[1.0.0, )",
+          "Microsoft.UI.Xaml": "[2.8.0, )"
+        }
+      },
       "microsoft.reactnative": {
         "type": "Project",
         "dependencies": {
@@ -179,6 +186,13 @@
         }
       },
       "rnsketchcanvas": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.ReactNative": "[1.0.0, )",
+          "Microsoft.UI.Xaml": "[2.8.0, )"
+        }
+      },
+      "rnsvg": {
         "type": "Project",
         "dependencies": {
           "Microsoft.ReactNative": "[1.0.0, )",


### PR DESCRIPTION
## Description

Create per-category pages in the gallery app (e.g. all "Basic Input" components). The home page now instead displays new and recent. And to aid in navigation to the category pages, add a current page "pill" to the drawer navigation view.

### Why

Resolves #433
Resolves #434 
Resolves #435 

### What

- Nav items display a selected "pill" for current page
- Home page shows 2 grouped lists (new and updated)
- Added a page for each category, filtered to that category
- Clicking on the category header in the nav view opens that category page* *well, not always, because Drawer has quirks; only when already expanded
- Drawer automatically expands category group if your current page is in that group

## Screenshots

![image](https://github.com/microsoft/react-native-gallery/assets/26607885/7d898ea3-351f-4f85-95a4-a4261d78565f)

![image](https://github.com/microsoft/react-native-gallery/assets/26607885/bada4b2f-d2d9-4d18-8590-01bbc2986440)

![image](https://github.com/microsoft/react-native-gallery/assets/26607885/378220f8-e42f-428d-9a95-c8fe05799a6e)

![image](https://github.com/microsoft/react-native-gallery/assets/26607885/998c1932-74d6-4aec-a755-3b347be2fa6d)




