### PR TITLE
Refactor: Fetch high contrast state via a cross platform hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,8 +22,8 @@ import {
   ThemeSetterContext,
 } from './themes/Theme';
 import {PlatformColor} from 'react-native';
-import {AppTheme} from 'react-native-windows';
 import HighContrastTheme from './themes/HighContrastTheme';
+import useHighContrastState from './hooks/useHighContrastState';
 
 const styles = StyleSheet.create({
   menu: {
@@ -347,17 +347,7 @@ export default function App() {
   const colorScheme = useColorScheme();
   const theme = rawtheme === 'system' ? colorScheme! : rawtheme;
 
-  const [isHighContrast, setHighContrast] = React.useState(
-    AppTheme.isHighContrast,
-  );
-
-  React.useEffect(() => {
-    const subscription = AppTheme.addListener('highContrastChanged', () => {
-      setHighContrast(AppTheme.isHighContrast);
-    });
-
-    return () => subscription.remove();
-  });
+  const isHighContrast = useHighContrastState();
 
   return (
     <ThemeSetterContext.Provider value={setRawTheme}>

--- a/src/hooks/useHighContrastState.macos.ts
+++ b/src/hooks/useHighContrastState.macos.ts
@@ -1,0 +1,19 @@
+'use strict';
+
+import {AccessibilityInfo} from 'react-native-macos';
+import React from 'react';
+
+export default function useHighContrastState() {
+  const [isHighContrast, setHighContrast] = React.useState(false);
+
+  React.useEffect(() => {
+    const accessibilitySubscription = AccessibilityInfo.addEventListener(
+      'highContrastChanged',
+      (value) => {
+        setHighContrast(value);
+      },
+    );
+    return () => accessibilitySubscription.remove();
+  });
+  return isHighContrast;
+}

--- a/src/hooks/useHighContrastState.ts
+++ b/src/hooks/useHighContrastState.ts
@@ -1,0 +1,6 @@
+'use strict';
+
+// Not Implemented on React Native Core
+export default function useHighContrastState() {
+  return false;
+}

--- a/src/hooks/useHighContrastState.windows.ts
+++ b/src/hooks/useHighContrastState.windows.ts
@@ -1,0 +1,19 @@
+'use strict';
+
+import {AppTheme} from 'react-native-windows';
+import React from 'react';
+
+export default function useHighContrastState() {
+  const [isHighContrast, setHighContrast] = React.useState(
+    AppTheme.isHighContrast,
+  );
+
+  React.useEffect(() => {
+    const subscription = AppTheme.addListener('highContrastChanged', () => {
+      setHighContrast(AppTheme.isHighContrast);
+    });
+
+    return () => subscription.remove();
+  });
+  return isHighContrast;
+}


### PR DESCRIPTION
## Description

### Why

This is part of a series of commits to reduce dependence on React Native Windows specific APIs, and allow the gallery to potentially run on macOS. 

Currently, `App.tsx` uses a React Native Windows specific JS API to fetch the high contrast state. This adds a direct import to `react-native-windows` that isn't gated inside a platform check or file. This commit refactors the code to fetch high contrast state into a hook, so that the windows specific imports can be moved to a `foo.windows.tsx` file, and so that we can also implement the macOS / mobile implementations separately. 

### What

Moves high contrast fetching code to a new hook `useHighContrastState()`

## Screenshots

No change should be seen to final app. 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/470)