### PR TITLE
Remove unused `doNotInset` prop

### DIFF
--- a/src/ComponentListPage.tsx
+++ b/src/ComponentListPage.tsx
@@ -106,7 +106,7 @@ const ComponentListPage = ({route, navigation}: ComponentListPageProps) => {
 
   return isScreenFocused ? (
     <View>
-      <ScreenWrapper doNotInset={true}>
+      <ScreenWrapper>
         <ScrollView>
           {category !== undefined ? (
             <View style={styles.container}>

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -116,7 +116,7 @@ export const HomePage: React.FunctionComponent<{}> = ({navigation}) => {
 
   return isScreenFocused ? (
     <View>
-      <ScreenWrapper doNotInset={true}>
+      <ScreenWrapper>
         <ScrollView>
           <PageTitle />
           <View style={styles.container}>

--- a/src/components/ScreenWrapper.tsx
+++ b/src/components/ScreenWrapper.tsx
@@ -32,9 +32,7 @@ const createStyles = (colorScheme) =>
       borderTopLeftRadius: 8,
       borderColor: PlatformColor('SurfaceStrokeColorFlyoutBrush'),
       borderLeftWidth: 1,
-    },
-    insetNavItem: {
-      paddingLeft: 36,
+      paddingStart: 36,
     },
     menu: {
       margin: 5,
@@ -51,13 +49,8 @@ const createStyles = (colorScheme) =>
     },
   });
 
-type ScreenWrapperProps = React.PropsWithChildren<{
-  doNotInset?: boolean;
-}>;
-export function ScreenWrapper({
-  children,
-  doNotInset,
-}: ScreenWrapperProps): JSX.Element {
+type ScreenWrapperProps = React.PropsWithChildren<{}>;
+export function ScreenWrapper({children}: ScreenWrapperProps): JSX.Element {
   const navigation = useNavigation();
   const colorScheme = useColorScheme();
   const styles = createStyles(colorScheme);
@@ -92,9 +85,7 @@ export function ScreenWrapper({
           </TouchableHighlight>
         </View>
       </Pressable>
-      <View style={[styles.navItem, doNotInset ? {} : styles.insetNavItem]}>
-        {children}
-      </View>
+      <View style={styles.navItem}>{children}</View>
     </View>
   );
 }


### PR DESCRIPTION
## Description

### Why

This prop is always true. Let's just remove it. 

### What

Remove the prop `doNotInset` from ScreenWrapper


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/476)