### PR TITLE
Fixed Typo

### DIFF
--- a/src/examples/FlatListExamplePage.tsx
+++ b/src/examples/FlatListExamplePage.tsx
@@ -136,7 +136,7 @@ export const FlatListExamplePage: React.FunctionComponent<{}> = () => {
           style={{height: 50}}
         />
       </Example>
-      <Example title="A mutli-column FlatList." code={example5jsx}>
+      <Example title="A multi-column FlatList." code={example5jsx}>
         <FlatList
           data={Data}
           renderItem={renderItem}


### PR DESCRIPTION
## Description
There was a grammatical error in the FlatList page. Now there isn't.

### Why
Resolves a typo.

### What
Just changed a few letters.

## Screenshots
![immagine](https://github.com/user-attachments/assets/b0746ab3-7582-419e-9d68-e7a44b09e017)

