### PR TITLE
Fix broken URL on 'Getting Started' tile on Home page

### DIFF
--- a/src/components/TileGallery.tsx
+++ b/src/components/TileGallery.tsx
@@ -96,7 +96,7 @@ const TileGallery = () => {
     <HeaderTile
       title="Getting started"
       description="An overview of app development options, tools, and samples."
-      link="https://learn.microsoft.com/windows/apps/get-started/https://aka.ms/reactnative">
+      link="https://learn.microsoft.com/windows/apps/get-started/">
       <Image
         accessible={true}
         accessibilityRole="image"


### PR DESCRIPTION
## Description
Currently, the link on the Getting Started tile on home page is broken. This fixes the url.
### Why

Resolves #481 

### What

Change tile link property

## Screenshots

Page linked before: 
![image](https://github.com/user-attachments/assets/727d4d66-d3f0-4211-bac2-0cc776c2de4e)

Page linked after:
![image](https://github.com/user-attachments/assets/e2c64865-cfdc-48dc-b52e-6afe21933de6)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/482)