### PR TITLE
Update bundle entry file when building in Release mode

### DIFF
--- a/windows/rngallery/rngallery.vcxproj
+++ b/windows/rngallery/rngallery.vcxproj
@@ -214,6 +214,9 @@
   <ItemGroup>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <PropertyGroup>
+    <BundleEntryFile Condition="'$(Configuration)'=='Release'">index.ts</BundleEntryFile>
+  </PropertyGroup>
   <!-- lottie-react-native imports -->
   <PropertyGroup Label="LottieReactNativeProps">
     <LottieReactNativeDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\lottie-react-native\package.json'))\node_modules\lottie-react-native</LottieReactNativeDir>


### PR DESCRIPTION
## Description
When trying to build Gallery in Release mode in order to publish the update to 0.75 to the store, was hitting the following error: 
>Error	MSB3073	The command "npx react-native bundle --platform windows --entry-file "index.js" --bundle-output "C:\new-account-repos\react-native-gallery\windows\rngallery\Bundle\index.windows.bundle" --assets-dest "C:\new-account-repos\react-native-gallery\windows\rngallery\Bundle" --dev false --reset-cache --sourcemap-output "C:\new-account-repos\react-native-gallery\windows\x64\Release\rngallery\sourcemaps\react\index.windows.bundle.packager.map" --minify false" exited with code 1.	rngallery	C:\new-account-repos\react-native-gallery\node_modules\react-native-windows\PropertySheets\Bundle.Common.targets	16		
Error		The resource `C:\new-account-repos\react-native-gallery\index.js` was not found.	rngallery	C:\new-account-repos\react-native-gallery\windows\rngallery\EXEC	1

This PR updates the `<BundleEntryFile>` for Gallery from `index.js`, which is defined by default [here](https://github.com/microsoft/react-native-windows/blob/cad91ffb811ea7a02cba05b17931663979a2ac52/vnext/PropertySheets/Bundle.props#L49). to `index.ts`.
### Why

Fix error above to allow store publish.

### What
Edit `<BundleEntryFile>` to `index.ts`.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/488)