### PR TITLE
Fix tile gallery link accessibility

### DIFF
--- a/src/components/TileGallery.tsx
+++ b/src/components/TileGallery.tsx
@@ -80,7 +80,8 @@ const HeaderTile = (props: HeaderTileType): JSX.Element => {
       onPressOut={() => setIsPressing(false)}
       onHoverIn={() => setIsHovered(true)}
       onHoverOut={() => setIsHovered(false)}
-      accessibilityRole="link">
+      accessibilityRole="link"
+      accessibilityLabel={props.title}>
       <View style={styles.tileIconContent}>{props.children}</View>
       <Text style={styles.tileTitle}>{props.title}</Text>
       <Text style={styles.tileDescription}>{props.description}</Text>

--- a/src/components/TileGallery.tsx
+++ b/src/components/TileGallery.tsx
@@ -80,7 +80,7 @@ const HeaderTile = (props: HeaderTileType): JSX.Element => {
       onPressOut={() => setIsPressing(false)}
       onHoverIn={() => setIsHovered(true)}
       onHoverOut={() => setIsHovered(false)}
-      accessibilityRole="link"
+      accessibilityRole="button"
       accessibilityLabel={props.title}>
       <View style={styles.tileIconContent}>{props.children}</View>
       <Text style={styles.tileTitle}>{props.title}</Text>


### PR DESCRIPTION
## Description

Fix some issues with the tile gallery links

### Why

Resolves #446

### What

- Manually specify an accessibility label, avoiding the auto concatenation of all elements that introduced the link character. 
- Specifying a "link" role gives the right type in the inspector... but doesn't come with an invoke action. Falling back to "button" no longer matches the WinUI 3 Gallery, but passes the accessibility inspection. Workaround for https://github.com/microsoft/react-native-windows/issues/13861

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/489)