### PR TITLE
Change accessible name values and add accessibility announcements on Clipboard example page

### DIFF
--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -3719,7 +3719,7 @@ exports[`Clipboard Example Page 1`] = `
                 }
               >
                 <View
-                  accessibilityLabel="Example copy text"
+                  accessibilityLabel="Copy text to the Clipboard"
                   accessibilityRole="button"
                   accessibilityState={
                     {
@@ -4004,7 +4004,7 @@ exports[`Clipboard Example Page 1`] = `
                 }
               >
                 <View
-                  accessibilityLabel="Example paste text"
+                  accessibilityLabel="Paste text from the Clipboard"
                   accessibilityRole="button"
                   accessibilityState={
                     {

--- a/src/examples/ClipboardExamplePage.tsx
+++ b/src/examples/ClipboardExamplePage.tsx
@@ -1,6 +1,6 @@
 'use strict';
 import React, {useState} from 'react';
-import {Button, Text, TextInput, View} from 'react-native';
+import {AccessibilityInfo, Button, Text, TextInput, View} from 'react-native';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
 import Clipboard from '@react-native-clipboard/clipboard';
@@ -45,7 +45,10 @@ export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
           <Button
             accessibilityLabel="Copy text to the Clipboard"
             title="Copy text to the Clipboard"
-            onPress={() => Clipboard.setString(textToCopy)}
+            onPress={() => {
+              Clipboard.setString(textToCopy);
+              AccessibilityInfo.announceForAccessibility('copied');
+            }}
           />
           <TextInput
             accessibilityLabel="Example set text to copy"
@@ -60,7 +63,10 @@ export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
           <Button
             accessibilityLabel="Paste text from the Clipboar"
             title="Paste text from the Clipboard"
-            onPress={() => getClipboardText()}
+            onPress={() => {
+              getClipboardText();
+              AccessibilityInfo.announceForAccessibility('pasted');
+            }}
           />
           <Text>{textFromClipboard}</Text>
         </View>

--- a/src/examples/ClipboardExamplePage.tsx
+++ b/src/examples/ClipboardExamplePage.tsx
@@ -43,7 +43,7 @@ export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
       <Example title="Copy text to the Clipboard." code={example1jsx}>
         <View style={{alignItems: 'flex-start', gap: 12}}>
           <Button
-            accessibilityLabel="Example copy text"
+            accessibilityLabel="Copy text to the Clipboard"
             title="Copy text to the Clipboard"
             onPress={() => Clipboard.setString(textToCopy)}
           />
@@ -58,7 +58,7 @@ export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
       <Example title="Paste text from the Clipboard." code={example2jsx}>
         <View style={{alignItems: 'flex-start', gap: 12}}>
           <Button
-            accessibilityLabel="Example paste text"
+            accessibilityLabel="Paste text from the Clipboar"
             title="Paste text from the Clipboard"
             onPress={() => getClipboardText()}
           />

--- a/src/examples/ClipboardExamplePage.tsx
+++ b/src/examples/ClipboardExamplePage.tsx
@@ -47,7 +47,9 @@ export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
             title="Copy text to the Clipboard"
             onPress={() => {
               Clipboard.setString(textToCopy);
-              AccessibilityInfo.announceForAccessibility('Text copied to clipboard');
+              AccessibilityInfo.announceForAccessibility(
+                'Text copied to clipboard',
+              );
             }}
           />
           <TextInput
@@ -65,7 +67,9 @@ export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
             title="Paste text from the Clipboard"
             onPress={() => {
               getClipboardText();
-              AccessibilityInfo.announceForAccessibility('Text pasted from clipboard');
+              AccessibilityInfo.announceForAccessibility(
+                'Text pasted from clipboard',
+              );
             }}
           />
           <Text>{textFromClipboard}</Text>

--- a/src/examples/ClipboardExamplePage.tsx
+++ b/src/examples/ClipboardExamplePage.tsx
@@ -61,7 +61,7 @@ export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
       <Example title="Paste text from the Clipboard." code={example2jsx}>
         <View style={{alignItems: 'flex-start', gap: 12}}>
           <Button
-            accessibilityLabel="Paste text from the Clipboar"
+            accessibilityLabel="Paste text from the Clipboard"
             title="Paste text from the Clipboard"
             onPress={() => {
               getClipboardText();

--- a/src/examples/ClipboardExamplePage.tsx
+++ b/src/examples/ClipboardExamplePage.tsx
@@ -47,7 +47,7 @@ export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
             title="Copy text to the Clipboard"
             onPress={() => {
               Clipboard.setString(textToCopy);
-              AccessibilityInfo.announceForAccessibility('copied');
+              AccessibilityInfo.announceForAccessibility('Text copied to clipboard');
             }}
           />
           <TextInput
@@ -65,7 +65,7 @@ export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
             title="Paste text from the Clipboard"
             onPress={() => {
               getClipboardText();
-              AccessibilityInfo.announceForAccessibility('pasted');
+              AccessibilityInfo.announceForAccessibility('Text pasted from clipboard');
             }}
           />
           <Text>{textFromClipboard}</Text>


### PR DESCRIPTION
## Description
Changes accessibilityLabel values to fix accessible names on buttons on Clipboard page. Adds accessibility announcement when pressing 'Copy to clipboard' and 'Paste to clipboard' buttons. 

### Why

Resolves #493
Resolves #494 

### What

Change accessibilityLabel values, and add accessibilityAnnouncement calls.

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/d3062147-e23d-4639-959d-bd8b8b367146)

After:
![image](https://github.com/user-attachments/assets/1fab50c4-240e-418a-8f94-8d504a907c4f)

*Same applies to 'Paste text from clipboard' button
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/506)