### PR TITLE
Add accessibility announcement to 'Copy from Clipboard' buttons

### DIFF
--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -47,7 +47,7 @@ const CopyToClipboardButton = ({content}: CopyToClipboardButtonProps) => {
       style={styles.background}
       onPress={() => {
         Clipboard.setString(content);
-        AccessibilityInfo.announceForAccessibility('copied');
+        AccessibilityInfo.announceForAccessibility('Text copied to clipboard');
       }}
       onPressIn={() => setIsPressing(true)}
       onPressOut={() => setIsPressing(false)}

--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import {AccessibilityInfo, Pressable, StyleSheet, PlatformColor, Text} from 'react-native';
+import {
+  AccessibilityInfo,
+  Pressable,
+  StyleSheet,
+  PlatformColor,
+  Text,
+} from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 
 const createButtonStyles = (isHovered: boolean, isPressing: boolean) =>

--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Pressable, StyleSheet, PlatformColor, Text} from 'react-native';
+import {AccessibilityInfo, Pressable, StyleSheet, PlatformColor, Text} from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 
 const createButtonStyles = (isHovered: boolean, isPressing: boolean) =>
@@ -39,7 +39,10 @@ const CopyToClipboardButton = ({content}: CopyToClipboardButtonProps) => {
       accessibilityLabel={helpText}
       tooltip={helpText}
       style={styles.background}
-      onPress={() => Clipboard.setString(content)}
+      onPress={() => {
+        Clipboard.setString(content);
+        AccessibilityInfo.announceForAccessibility('copied');
+      }}
       onPressIn={() => setIsPressing(true)}
       onPressOut={() => setIsPressing(false)}
       onHoverIn={() => setIsHovered(true)}


### PR DESCRIPTION
## Description
Adds an accessibility announcement to indicate success when using the 'Copy to Clipboard' buttons in the app.

### Why

Resolves #495 

### What

Added an accessibility announcement call to the CopyToClipboard component.

## Screenshots

N/A. Tested with Narrator and it announces 'Copied' every time the button is pressed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/507)