### PR TITLE
Fix navigation item pill background color and single selection VirtualizedList items to work in high contrast modes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
     alignItems: 'flex-end',
   },
   navigationItemPill: {
-    backgroundColor: PlatformColor('AccentFillColorDefaultBrush'),
+    backgroundColor: PlatformColor('SystemControlHighlightBaseMediumHighBrush'),
     borderRadius: 2,
     right: 6,
     width: 3,

--- a/src/examples/VirtualizedListExamplePage.tsx
+++ b/src/examples/VirtualizedListExamplePage.tsx
@@ -208,7 +208,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{}> = () => {
     },
     title: {
       fontSize: 20,
-      color: PlatformColor('SystemControlHighlightAltBaseHighBrush'),
+      color: PlatformColor('SystemControlHighlightBaseHighBrush'),
     },
   });
 

--- a/src/examples/VirtualizedListExamplePage.tsx
+++ b/src/examples/VirtualizedListExamplePage.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   TouchableHighlight,
   ScrollView,
+  PlatformColor,
 } from 'react-native';
 import React, {useState} from 'react';
 import {Example} from '../components/Example';
@@ -203,11 +204,11 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{}> = () => {
       padding: 5,
       paddingHorizontal: 10,
       marginVertical: 3,
-      backgroundColor: colors.border,
+      backgroundColor: PlatformColor('SystemControlHighlightBaseLowBrush'),
     },
     title: {
       fontSize: 20,
-      color: colors.text,
+      color: PlatformColor('SystemControlHighlightAltBaseHighBrush'),
     },
   });
 


### PR DESCRIPTION
## Description
Uses PlatformColor to set the background color of the navigation item pill to work in high contrast modes.
Uses PlatformColor to set the background and text color of the single selection VirtualizedList items to work in high contrast modes.
### Why

Resolves #501
Resolves #500 

### What

Change backgroundColor property value for navigation item pill and text and background color for single selection VitalizedList items.

## Screenshots

Before (in aquatic theme):
![image](https://github.com/user-attachments/assets/fc6a8e38-dca9-4458-9d6d-8675f19e9158)

After (in aquatic theme):
![high contrast pill success](https://github.com/user-attachments/assets/672f7a66-66a4-4930-add1-efd1bb5de851)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/520)