### PR TITLE
[BugFix] Add accessibilityLabel for icon

### DIFF
--- a/NewArch/src/components/ScreenWrapper.tsx
+++ b/NewArch/src/components/ScreenWrapper.tsx
@@ -87,7 +87,7 @@ export function ScreenWrapper({
             onPress={() => navigation.dispatch(DrawerActions.openDrawer())}
             activeOpacity={0.5783}
             underlayColor="rgba(0, 0, 0, 0.0241);">
-            <Text style={styles.icon}>&#xE700;</Text>
+            <Text style={styles.icon} accessibilityLabel="Navigation bar hamburger icon text">&#xE700;</Text>
           </TouchableHighlight>
         </View>
       </Pressable>


### PR DESCRIPTION
## Description

### Why

Build Details:
OS Version: Dev (OS Build 27695.1000)
App: React Native Gallery
App Version: 1.0.18.0
React Native Windows Version: 0.75.0
AT: Fast Pass

Repro-Steps:
Launch the React Native Gallery app.
Navigate to ‘Home’ button present in left navigation pane and invoke it.
Now run fast pass and observe the issue.
Actual Result:
The Name property is containing characters in the private Unicode range.

Expected Result:
The Name property must not contain any characters in the private Unicode range.

User Impact:
Users with visual impairment who rely on screen reader will be misguided if narrator announces incorrect control type of the item.

Link to ADO bug: https://microsoft.visualstudio.com/OS/_workitems/edit/54111816

What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves https://github.com/microsoft/react-native-gallery/issues/518

### What

What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.
This should be able to be resolved by changing the value of the accessibilityLabel property of the affected component 

## Screenshots

Add any relevant screen captures here from before or after your changes.

![image](https://github.com/user-attachments/assets/b5193649-9724-4bfa-957e-39ffcbdf8b6d)
