### PR TITLE
Add accessibilityLabel for icon text

### DIFF
--- a/NewArch/src/components/ScreenWrapper.tsx
+++ b/NewArch/src/components/ScreenWrapper.tsx
@@ -88,7 +88,7 @@ export function ScreenWrapper({
             onPress={() => navigation.dispatch(DrawerActions.openDrawer())}
             activeOpacity={0.5783}
             underlayColor="rgba(0, 0, 0, 0.0241);">
-            <Text style={styles.icon}>&#xE700;</Text>
+            <Text style={styles.icon} accessibilityLabel="Navigation bar hamburger icon text">&#xE700;</Text>
           </TouchableHighlight>
         </View>
       </Pressable>


### PR DESCRIPTION
## Description

### Why

Build Details:
OS Version: Dev (OS Build 27695.1000)
App: React Native Gallery
App Version: 1.0.18.0
React Native Windows Version: 0.75.0
AT: Fast Pass

Repro-Steps:
Launch the React Native Gallery app.
Navigate to ‘Home’ button present in left navigation pane and invoke it.
Now run fast pass and observe the issue.
Actual Result:
The Name property is containing characters in the private Unicode range.

Expected Result:
The Name property must not contain any characters in the private Unicode range.

User Impact:
Users with visual impairment who rely on screen reader will be misguided if narrator announces incorrect control type of the item.

Link to ADO bug: https://microsoft.visualstudio.com/OS/_workitems/edit/54111816

What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves https://github.com/microsoft/react-native-gallery/issues/518

### What

What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.
This should be able to be resolved by changing the value of the accessibilityLabel property of the affected component 

## Screenshots

Add any relevant screen captures here from before or after your changes.
Before:
![image](https://github.com/user-attachments/assets/3b6e4360-fb13-4b98-b96e-bf3d132858f4)

After: 
![image](https://github.com/user-attachments/assets/288649c8-f64b-4725-9890-a8c04f342232)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/546)