### PR TITLE
[BugFix] Replace "Open Popup" to "Open Flyout" in Flyout

### DIFF
--- a/NewArch/src/examples/FlyoutExamplePage.tsx
+++ b/NewArch/src/examples/FlyoutExamplePage.tsx
@@ -27,7 +27,7 @@ export const FlyoutExamplePage: React.FunctionComponent<{}> = () => {
   }}
   activeOpacity={0.2}
   underlayColor={colors.border}>
-  <Text>Open Popup</Text>
+  <Text>Open Flyout</Text>
 </TouchableHighlight>
 <Flyout
   isOpen={showFlyout1}
@@ -52,7 +52,7 @@ export const FlyoutExamplePage: React.FunctionComponent<{}> = () => {
   }}
   activeOpacity={0.2}
   underlayColor={colors.border}>
-  <Text>Open Popup</Text>
+  <Text>Open Flyout</Text>
 </TouchableHighlight>
 <Flyout
   isOpen={showFlyout2}
@@ -78,7 +78,7 @@ export const FlyoutExamplePage: React.FunctionComponent<{}> = () => {
   }}
   activeOpacity={0.2}
   underlayColor={colors.border}>
-  <Text>Open Popup</Text>
+  <Text>Open Flyout</Text>
 </TouchableHighlight>
 <Flyout
   isOpen={showFlyout3}
@@ -106,7 +106,7 @@ export const FlyoutExamplePage: React.FunctionComponent<{}> = () => {
   ref={myRef}
   activeOpacity={0.2}
   underlayColor={colors.border}>
-  <Text>Open Popup</Text>
+  <Text>Open Flyout</Text>
 </TouchableHighlight>
 <Flyout
   isOpen={showFlyout4}
@@ -163,7 +163,7 @@ export const FlyoutExamplePage: React.FunctionComponent<{}> = () => {
           accessibilityRole="button"
           activeOpacity={0.2}
           underlayColor={colors.border}>
-          <Text style={{color: colors.text}}>Open Popup</Text>
+          <Text style={{color: colors.text}}>Open Flyout</Text>
         </TouchableHighlight>
         <Flyout
           isOpen={showFlyout1}
@@ -219,7 +219,7 @@ export const FlyoutExamplePage: React.FunctionComponent<{}> = () => {
           accessibilityRole="button"
           activeOpacity={0.2}
           underlayColor={colors.border}>
-          <Text style={{color: colors.text}}>Open Popup</Text>
+          <Text style={{color: colors.text}}>Open Flyout</Text>
         </TouchableHighlight>
         <Flyout
           isOpen={showFlyout2}
@@ -276,7 +276,7 @@ export const FlyoutExamplePage: React.FunctionComponent<{}> = () => {
           accessibilityRole="button"
           activeOpacity={0.2}
           underlayColor={colors.border}>
-          <Text style={{color: colors.text}}>Open Popup</Text>
+          <Text style={{color: colors.text}}>Open Flyout</Text>
         </TouchableHighlight>
         <Flyout
           isOpen={showFlyout3}
@@ -337,7 +337,7 @@ export const FlyoutExamplePage: React.FunctionComponent<{}> = () => {
           ref={myRef}
           activeOpacity={0.2}
           underlayColor={colors.border}>
-          <Text style={{color: colors.text}}>Open Popup</Text>
+          <Text style={{color: colors.text}}>Open Flyout</Text>
         </TouchableHighlight>
         <Flyout
           isOpen={showFlyout4}


### PR DESCRIPTION
## Description

Button to open Flyouts in all 4 examples say "Open Popup" instead of "Open Flyout"
![image](https://github.com/microsoft/react-native-gallery/assets/1422161/34a35aca-8938-438f-94ea-871bbd60ea8d)

### Why

What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves https://github.com/microsoft/react-native-gallery/issues/457

### What

What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

Replace "Open Popup" to "Open Flyout" in Flyout

## Screenshots

Add any relevant screen captures here from before or after your changes.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/547)