### PR TITLE
Updated app title from "NewArch" to "React Native Gallery"

### DIFF
--- a/NewArch/windows/NewArch/NewArch.cpp
+++ b/NewArch/windows/NewArch/NewArch.cpp
@@ -10,15 +10,18 @@
 
 // A PackageProvider containing any turbo modules you define within this app project
 struct CompReactPackageProvider
-    : winrt::implements<CompReactPackageProvider, winrt::Microsoft::ReactNative::IReactPackageProvider> {
- public: // IReactPackageProvider
-  void CreatePackage(winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) noexcept {
+    : winrt::implements<CompReactPackageProvider, winrt::Microsoft::ReactNative::IReactPackageProvider>
+{
+public: // IReactPackageProvider
+  void CreatePackage(winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) noexcept
+  {
     AddAttributedModules(packageBuilder, true);
   }
 };
 
 // The entry point of the Win32 application
-_Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR /* commandLine */, int showCmd) {
+_Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR /* commandLine */, int showCmd)
+{
   // Initialize WinRT
   winrt::init_apartment(winrt::apartment_type::single_threaded);
 
@@ -70,7 +73,7 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR 
 
   // Get the AppWindow so we can configure its initial title and size
   auto appWindow{reactNativeWin32App.AppWindow()};
-  appWindow.Title(L"NewArch");
+  appWindow.Title(L"React Native Gallery");
   appWindow.Resize({1000, 1000});
 
   // Get the ReactViewOptions so we can set the initial RN component to load


### PR DESCRIPTION
## Description

### Why

App title is showing as "NewArch" because it is using the component name used to generate from template.

Resolves #557

### What

Updated the string in the app cpp file (NewArch.cpp). Note that the `displayString` in the app.json does not affect this.

## Screenshots

![image](https://github.com/user-attachments/assets/6f94510c-f7a1-485d-847c-12e1c87f8e70)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/559)