### PR TITLE
[BugFix] [Accessibility] [React Native New Architecture -> Modal]: Name property is not defined for all the 'Open Modal' buttons.

### DIFF
--- a/NewArch/src/examples/ModalExamplePage.tsx
+++ b/NewArch/src/examples/ModalExamplePage.tsx
@@ -8,6 +8,15 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
   const [modal1, setModal1] = React.useState(false);
   const [modal2, setModal2] = React.useState(false);
   const [modal3, setModal3] = React.useState(false);
+  const changeModal1 = () => {
+    setModal1(!modal1);
+  };
+  const changeModal2 = () => {
+    setModal2(!modal2);
+  };
+  const changeModal3 = () => {
+    setModal3(!modal3);
+  };
 
   const [onDismissCount, setOnDismissCount] = React.useState(0);
   const [onShowCount, setOnShowCount] = React.useState(0);
@@ -85,24 +94,16 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
         <Button
           title="Open Modal"
           accessibilityLabel='Open Modal'
-          onPress={() => {
-            setModal1(!modal1);
-          }}
-          onAccessibilityTap={() => {
-            setModal1(!modal1);
-          }}/>
+          onPress={changeModal1}
+          onAccessibilityTap={changeModal1}/>
         <Modal visible={modal1}>
           <View style={{width: 500, height: 50}}>
             <Text>This is a simple Modal</Text>
             <Button
               title="Close Modal"
               accessibilityLabel='Close Modal'
-              onPress={() => {
-                setModal1(!modal1);
-              }}
-              onAccessibilityTap={() => {
-                setModal1(!modal1);
-              }}/>
+              onPress={changeModal1}
+              onAccessibilityTap={changeModal1}/>
           </View>
         </Modal>
       </Example>
@@ -112,12 +113,8 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
         <Button
           title="Open Modal"
           accessibilityLabel='Open Modal'
-          onPress={() => {
-            setModal2(!modal2);
-          }}
-          onAccessibilityTap={() => {
-            setModal2(!modal2);
-          }}/>
+          onPress={changeModal2}
+          onAccessibilityTap={changeModal2}/>
         <Modal visible={modal2}>
           <View style={[styles.centeredView, styles.modalBackdrop]}>
             <View style={styles.modalView}>
@@ -128,12 +125,8 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
                 title="Close Modal"
                 accessibilityLabel='Close Modal'
                 style={styles.button}
-                onPress={() => {
-                  setModal2(!modal2);
-                }}
-                onAccessibilityTap={() => {
-                  setModal2(!modal2);
-                }}/>
+                onPress={changeModal2}
+                onAccessibilityTap={changeModal2}/>
             </View>
           </View>
         </Modal>
@@ -142,12 +135,8 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
         <Button
           title="Open Modal"
           accessibilityLabel="Open Modal"
-          onPress={() => {
-            setModal3(!modal3);
-          }}
-          onAccessibilityTap={() => {
-            setModal3(!modal3);
-          }}/>
+          onPress={changeModal3}
+          onAccessibilityTap={changeModal3}/>
           <View style={styles.container}>
               <Text style={{fontWeight: 'bold'}}>Modal Events</Text>
               <Text>onShow event Count = {onShowCount}</Text>
@@ -170,12 +159,8 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
             <Button
               title="Close Modal"
               accessibilityLabel="Close Modal"
-              onPress={() => {
-                setModal3(!modal3);
-              }}
-              onAccessibilityTap={() => {
-                setModal3(!modal3);
-              }}/>
+              onPress={changeModal3}
+              onAccessibilityTap={changeModal3}/>
           </View>
         </Modal>
       </Example>

--- a/NewArch/src/examples/ModalExamplePage.tsx
+++ b/NewArch/src/examples/ModalExamplePage.tsx
@@ -14,27 +14,27 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
 
   const example1jsx = `
   const [modal1, setModal1] = React.useState(false);
-  <Button title='Open Modal' onPress={()=>{setModal1(!modal1)}}></Button>
+  <Button title='Open Modal' accessibilityLabel='Open Modal' onPress={()=>{setModal1(!modal1)}} onAccessibilityTap={()=>{setModal1(!modal1)}}/>
   <Modal visible={modal1}>
     <View style={{width: 500, height: 200}}>
       <Text>This is a Modal Screen</Text>
-      <Button title='Close Modal' onPress={()=>{setModal1(!modal1)}}></Button>
+      <Button title='Close Modal' accessibilityLabel='Close Modal' onPress={()=>{setModal1(!modal1)}} onAccessibilityTap={()=>{setModal1(!modal1)}}/>
     </View>
   </Modal>`;
   const example2jsx = `
   const [modal2, setModal2] = React.useState(false);
-  <Button title='Open Modal' onPress={()=>{setModal2(!modal2)}}></Button>
+  <Button title='Open Modal' accessibilityLabel='Open Modal' onPress={()=>{setModal2(!modal2)}} onAccessibilityTap={()=>{setModal2(!modal2)}}/>
    <Modal visible={modal2}>
      <View style={[styles.centeredView, styles.modalBackdrop]}>
       <View style={styles.modalView}>
        <Text style={styles.textStyle}>This is a Modal with more complex styling</Text>
-       <Button title='Close Modal' style={styles.button} onPress={()=>{setModal2(!modal2)}}></Button>
+       <Button title='Close Modal' accessibilityLabel='Close Modal' style={styles.button} onPress={()=>{setModal2(!modal2)}} onAccessibilityTap={()=>{setModal2(!modal2)}}/>
       </View>
      </View>
     </Modal>`;
   const example3jsx = `
   const [modal3, setModal3] = React.useState(false);
-  <Button title='Open Modal' onPress={()=>{setModal3(!modal3)}}></Button>
+  <Button title='Open Modal' accessibilityLabel='Open Modal' onPress={()=>{setModal3(!modal3)}} onAccessibilityTap={()=>{setModal3(!modal3)}}/>
     <Modal
       visible={modal3}
       onDismiss={() => {
@@ -51,9 +51,13 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
       </View>
         <Button
           title="Close Modal"
+          accessibilityLabel="Close Modal"
           onPress={() => {
           setModal3(!modal3);
-          }}></Button>
+          }} 
+          onAccessibilityTap={() => {
+            setModal3(!modal3);
+          }}/>
       </View>
     </Modal>`;
 
@@ -80,17 +84,25 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
       <Example title="A simple Modal." code={example1jsx}>
         <Button
           title="Open Modal"
+          accessibilityLabel='Open Modal'
           onPress={() => {
             setModal1(!modal1);
-          }} />
+          }}
+          onAccessibilityTap={() => {
+            setModal1(!modal1);
+          }}/>
         <Modal visible={modal1}>
           <View style={{width: 500, height: 50}}>
             <Text>This is a simple Modal</Text>
             <Button
               title="Close Modal"
+              accessibilityLabel='Close Modal'
               onPress={() => {
                 setModal1(!modal1);
-              }} />
+              }}
+              onAccessibilityTap={() => {
+                setModal1(!modal1);
+              }}/>
           </View>
         </Modal>
       </Example>
@@ -99,9 +111,13 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
         code={example2jsx}>
         <Button
           title="Open Modal"
+          accessibilityLabel='Open Modal'
           onPress={() => {
             setModal2(!modal2);
-          }} />
+          }}
+          onAccessibilityTap={() => {
+            setModal2(!modal2);
+          }}/>
         <Modal visible={modal2}>
           <View style={[styles.centeredView, styles.modalBackdrop]}>
             <View style={styles.modalView}>
@@ -110,10 +126,14 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
               </Text>
               <Button
                 title="Close Modal"
+                accessibilityLabel='Close Modal'
                 style={styles.button}
                 onPress={() => {
                   setModal2(!modal2);
-                }} />
+                }}
+                onAccessibilityTap={() => {
+                  setModal2(!modal2);
+                }}/>
             </View>
           </View>
         </Modal>
@@ -121,9 +141,13 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
       <Example title="A Modal with events" code={example3jsx}>
         <Button
           title="Open Modal"
+          accessibilityLabel="Open Modal"
           onPress={() => {
             setModal3(!modal3);
-          }} />
+          }}
+          onAccessibilityTap={() => {
+            setModal3(!modal3);
+          }}/>
           <View style={styles.container}>
               <Text style={{fontWeight: 'bold'}}>Modal Events</Text>
               <Text>onShow event Count = {onShowCount}</Text>
@@ -145,9 +169,13 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
             </View>
             <Button
               title="Close Modal"
+              accessibilityLabel="Close Modal"
               onPress={() => {
                 setModal3(!modal3);
-              }} />
+              }}
+              onAccessibilityTap={() => {
+                setModal3(!modal3);
+              }}/>
           </View>
         </Modal>
       </Example>


### PR DESCRIPTION
## Description

### Why

accessibilityLabel and onaccessibilitytap is not defined for all modal buttons.

Resolves [#582]

### What

Added the above accessibility props for all modal buttons

## Screenshots

![image](https://github.com/user-attachments/assets/b64c3fc8-a7d9-4db1-88a8-5edaf877b921)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/598)