### PR TITLE
[BugFix] [React Native New Architecture]: The 'colored button' is not visible clearly in both the high contrast themes

### DIFF
--- a/NewArch/src/examples/ButtonExamplePage.tsx
+++ b/NewArch/src/examples/ButtonExamplePage.tsx
@@ -48,7 +48,7 @@ export const ButtonExamplePage: React.FunctionComponent<{}> = () => {
           title="Button"
           color={
             Platform.OS === 'windows'
-              ? PlatformColor('Accent')
+              ? PlatformColor('SystemChromeMediumLowColor')
               : 'silver'
           }
           accessibilityLabel={'example colored button2'}

--- a/NewArch/src/examples/ButtonExamplePage.tsx
+++ b/NewArch/src/examples/ButtonExamplePage.tsx
@@ -46,7 +46,11 @@ export const ButtonExamplePage: React.FunctionComponent<{}> = () => {
       <Example title="A colored Button." code={example2jsx}>
         <Button
           title="Button"
-          color={PlatformColor('Accent')}
+          color={
+            Platform.OS === 'windows'
+              ? PlatformColor('Accent')
+              : 'silver'
+          }
           accessibilityLabel={'example colored button2'}
           onPress={() => {}}
           onAccessibilityTap={() => {}}

--- a/NewArch/src/examples/ButtonExamplePage.tsx
+++ b/NewArch/src/examples/ButtonExamplePage.tsx
@@ -1,5 +1,5 @@
 'use strict';
-import {Button, Platform} from 'react-native';
+import {Button, Platform, PlatformColor} from 'react-native';
 import React, {useState} from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
@@ -46,11 +46,7 @@ export const ButtonExamplePage: React.FunctionComponent<{}> = () => {
       <Example title="A colored Button." code={example2jsx}>
         <Button
           title="Button"
-          color={
-            Platform.OS === 'windows'
-              ? 'blue'
-              : 'silver'
-          }
+          color={PlatformColor('Accent')}
           accessibilityLabel={'example colored button2'}
           onPress={() => {}}
           onAccessibilityTap={() => {}}


### PR DESCRIPTION
## Description

### Why

To fix button color accessibility issue for contrast themes

Resolves #592 

### What

Updated color "blue" to platfromcolor defined in theme.cpp in RNW

## Screenshots

BEFORE [Dessert]
![image](https://github.com/user-attachments/assets/1d74aeac-1f9d-4471-81fe-4978fc2f153e)

AFTER [Dessert]
![image](https://github.com/user-attachments/assets/fdbccea6-8e76-4438-b41f-bcc26709ed47)

BEFORE [Aquatic]
![image](https://github.com/user-attachments/assets/01f29a7a-7d0d-4046-83e0-18c4e59a73ba)

AFTER [Aquatic]
![image](https://github.com/user-attachments/assets/f0d2a8a3-a0e3-4ec2-80f5-b751af5272f9)

BEFORE [Normal]
![image](https://github.com/user-attachments/assets/0c7a4de5-3100-4861-9bec-7898f5799cbb)

AFTER [Normal]
![image](https://github.com/user-attachments/assets/bf737fd9-2895-4b31-9dd0-39d71170cad8)