### PR TITLE
[Bug Fix][Accesibility][React Native New Architecture]: Contents are getting truncated on applying text scaling to 200%. 

### DIFF
--- a/NewArch/src/components/ControlItem.tsx
+++ b/NewArch/src/components/ControlItem.tsx
@@ -28,7 +28,7 @@ const createStyles = (colors: any, isHovered: boolean, isPressing: boolean) =>
       flexDirection: 'row',
       gap: 16,
       width: 360,
-      height: 90,
+      minHeight: 90,
     },
     textIcon: {
       fontFamily: 'Segoe MDL2 Assets',

--- a/NewArch/src/components/TileGallery.tsx
+++ b/NewArch/src/components/TileGallery.tsx
@@ -28,7 +28,7 @@ const createStyles = (isHovered: boolean, _isPressing: boolean) =>
       padding: 24,
       gap: 4,
       width: 198,
-      height: 220,
+      minHeight: 220,
       alignItems: 'flex-start',
     },
     tileIconContent: {


### PR DESCRIPTION
## Description
Launch the React Native Gallery- Experimental app.
Navigate to the 'Expand menu' button and invoke it.
Navigate to 'Home' button and invoke it.
Apply text scaling and observe the changes.
Actual Result:
Contents are getting truncated on applying text scaling to 200%.
Note: Issue is repro'ing throughout the application.

Resolves [#600 ]

### What
The PixelRatio.getFontScale() multiplier was added to the tile dimensions (minWidth, maxWidth, and height) to make them scale proportionally with the user's font size accessibility settings.

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/c683b523-879e-487a-8ca9-dc676569802b)

After:

https://github.com/user-attachments/assets/eabba388-843d-4f86-86dd-b09f282c361a

![image](https://github.com/user-attachments/assets/39d18561-9b35-476c-b803-5d8645716790)




 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/603)