### PR TITLE
[Fix]  Keyboard focus is not moving to the opened modal dialog, on invoking 'Open modal' button

### DIFF
--- a/NewArch/src/examples/ModalExamplePage.tsx
+++ b/NewArch/src/examples/ModalExamplePage.tsx
@@ -57,6 +57,28 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
       </View>
     </Modal>`;
 
+  // Add refs for the first focusable element in each modal
+  const modal1FirstButtonRef = React.useRef<any>(null);
+  const modal2FirstButtonRef = React.useRef<any>(null);
+  const modal3FirstButtonRef = React.useRef<any>(null);
+
+  // Focus the first element when modal opens
+  React.useEffect(() => {
+    if (modal1 && modal1FirstButtonRef.current && typeof modal1FirstButtonRef.current.focus === 'function') {
+      modal1FirstButtonRef.current.focus();
+    }
+  }, [modal1]);
+  React.useEffect(() => {
+    if (modal2 && modal2FirstButtonRef.current && typeof modal2FirstButtonRef.current.focus === 'function') {
+      modal2FirstButtonRef.current.focus();
+    }
+  }, [modal2]);
+  React.useEffect(() => {
+    if (modal3 && modal3FirstButtonRef.current && typeof modal3FirstButtonRef.current.focus === 'function') {
+      modal3FirstButtonRef.current.focus();
+    }
+  }, [modal3]);
+
   return (
     <Page
       title="Modal"
@@ -87,6 +109,7 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
           <View style={{width: 500, height: 50}}>
             <Text>This is a simple Modal</Text>
             <Button
+              ref={modal1FirstButtonRef}
               title="Close Modal"
               onPress={() => {
                 setModal1(!modal1);
@@ -109,8 +132,8 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
                 This is a Modal with more complex styling
               </Text>
               <Button
+                ref={modal2FirstButtonRef}
                 title="Close Modal"
-                style={styles.button}
                 onPress={() => {
                   setModal2(!modal2);
                 }} />
@@ -144,6 +167,7 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
               <Text>onDismiss event Count = {onDismissCount}</Text>
             </View>
             <Button
+              ref={modal3FirstButtonRef}
               title="Close Modal"
               onPress={() => {
                 setModal3(!modal3);

--- a/NewArch/src/examples/ModalExamplePage.tsx
+++ b/NewArch/src/examples/ModalExamplePage.tsx
@@ -116,7 +116,8 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
         <Button
           title="Open Modal"
           accessibilityLabel="Open Modal"
-          onPress={changeModal1}/>
+          onPress={changeModal1}
+          onAccessibilityTap={changeModal1}/>
         <Modal visible={modal1}>
           <View style={{width: 500, height: 50}}>
             <Text>This is a simple Modal</Text>
@@ -135,7 +136,8 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
         <Button
           title="Open Modal"
           accessibilityLabel="Open Modal"
-          onPress={changeModal2}/>
+          onPress={changeModal2}
+          onAccessibilityTap={changeModal2}/>
         <Modal visible={modal2}>
           <View style={[styles.centeredView, styles.modalBackdrop]}>
             <View style={styles.modalView}>
@@ -156,7 +158,8 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
         <Button
           title="Open Modal"
           accessibilityLabel="Open Modal"
-          onPress={changeModal3}/>
+          onPress={changeModal3}
+          onAccessibilityTap={changeModal3}/>
           <View style={styles.container}>
               <Text style={{fontWeight: 'bold'}}>Modal Events</Text>
               <Text>onShow event Count = {onShowCount}</Text>

--- a/NewArch/src/examples/ModalExamplePage.tsx
+++ b/NewArch/src/examples/ModalExamplePage.tsx
@@ -116,8 +116,7 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
         <Button
           title="Open Modal"
           accessibilityLabel="Open Modal"
-          onPress={changeModal1}
-          onAccessibilityTap={changeModal1}/>
+          onPress={changeModal1}/>
         <Modal visible={modal1}>
           <View style={{width: 500, height: 50}}>
             <Text>This is a simple Modal</Text>
@@ -125,8 +124,7 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
               ref={modal1FirstButtonRef}
               title="Close Modal"
               accessibilityLabel="Close Modal"
-              onPress={changeModal1}
-              onAccessibilityTap={changeModal1}/>
+              onPress={changeModal1}/>
           </View>
         </Modal>
       </Example>
@@ -136,8 +134,7 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
         <Button
           title="Open Modal"
           accessibilityLabel="Open Modal"
-          onPress={changeModal2}
-          onAccessibilityTap={changeModal2}/>
+          onPress={changeModal2}/>
         <Modal visible={modal2}>
           <View style={[styles.centeredView, styles.modalBackdrop]}>
             <View style={styles.modalView}>
@@ -148,9 +145,7 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
                 ref={modal2FirstButtonRef}
                 title="Close Modal"
                 accessibilityLabel="Close Modal"
-                onPress={() => {
-                  setModal2(!modal2);
-                }} />
+                onPress={changeModal2}/>
             </View>
           </View>
         </Modal>
@@ -159,8 +154,7 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
         <Button
           title="Open Modal"
           accessibilityLabel="Open Modal"
-          onPress={changeModal3}
-          onAccessibilityTap={changeModal3}/>
+          onPress={changeModal3}/>
           <View style={styles.container}>
               <Text style={{fontWeight: 'bold'}}>Modal Events</Text>
               <Text>onShow event Count = {onShowCount}</Text>
@@ -184,8 +178,7 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
               ref={modal3FirstButtonRef}
               title="Close Modal"
               accessibilityLabel="Close Modal"
-              onPress={changeModal3}
-              onAccessibilityTap={changeModal3}/>
+              onPress={changeModal3}/>
           </View>
         </Modal>
       </Example>

--- a/NewArch/src/examples/ModalExamplePage.tsx
+++ b/NewArch/src/examples/ModalExamplePage.tsx
@@ -124,7 +124,8 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
               ref={modal1FirstButtonRef}
               title="Close Modal"
               accessibilityLabel="Close Modal"
-              onPress={changeModal1}/>
+              onPress={changeModal1}
+              onAccessibilityTap={changeModal1}/>
           </View>
         </Modal>
       </Example>
@@ -145,7 +146,8 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
                 ref={modal2FirstButtonRef}
                 title="Close Modal"
                 accessibilityLabel="Close Modal"
-                onPress={changeModal2}/>
+                onPress={changeModal2}
+                onAccessibilityTap={changeModal2}/>
             </View>
           </View>
         </Modal>
@@ -178,7 +180,8 @@ export const ModalExamplePage: React.FunctionComponent<{}> = () => {
               ref={modal3FirstButtonRef}
               title="Close Modal"
               accessibilityLabel="Close Modal"
-              onPress={changeModal3}/>
+              onPress={changeModal3}
+              onAccessibilityTap={changeModal3}/>
           </View>
         </Modal>
       </Example>


### PR DESCRIPTION
## Description
Users with motor impairment who rely on keyboard will face difficulties if keyboard focus does not move to the opened modal dialog.

### Why
Narrator wasnt focusing on close modal in view , which would hamper accessibility properties and wouldnt let the close modal happen from narrator control

Resolves [Add Relevant Issue Here]
https://github.com/microsoft/react-native-gallery/issues/587
### What
Set a ref on the first Button inside each Modal and call .focus() on it when the Modal opens.



## Screenshots

https://github.com/user-attachments/assets/00ae8dd8-e3aa-4de3-a6fc-737821944172




 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/604)