### PR TITLE
[Bug Fix] [React Native New Architecture]: Narrator is not announcing any success message on invoking 'Copy to clipboard' button.

### DIFF
--- a/NewArch/src/examples/ClipboardExamplePage.tsx
+++ b/NewArch/src/examples/ClipboardExamplePage.tsx
@@ -50,11 +50,19 @@ export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
             title="Copy text to the Clipboard"
             onPress={() => {
               Clipboard.setString(textToCopy);
+              // Issue #622: Workaround
+              // AccessibilityInfo.announceForAccessibility(
+              //   'Text copied to clipboard',
+              // );
               setAccessibilityValueCopy(''); // reset before reading to update on multiple clicks
               setAccessibilityValueCopy('Text copied to clipboard');
             }}
             onAccessibilityTap={() => {
               Clipboard.setString(textToCopy);
+              // Issue #622: Workaround
+              // AccessibilityInfo.announceForAccessibility(
+              //   'Text copied to clipboard',
+              // );
               setAccessibilityValueCopy('');
               setAccessibilityValueCopy('Text copied to clipboard');              
             }}
@@ -75,11 +83,19 @@ export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
             title="Paste text from the Clipboard"
             onPress={() => {
               getClipboardText();
+              // Issue #622: Workaround
+              // AccessibilityInfo.announceForAccessibility(
+              //   'Text pasted from clipboard',
+              // );
               setAccessibilityValuePaste('');
               setAccessibilityValuePaste('Text pasted from clipboard');             
             }}
             onAccessibilityTap={() => {
               getClipboardText();
+              // Issue #622: Workaround
+              // AccessibilityInfo.announceForAccessibility(
+              //   'Text pasted from clipboard',
+              // );
               setAccessibilityValuePaste('');
               setAccessibilityValuePaste('Text pasted from clipboard');
             }}

--- a/NewArch/src/examples/ClipboardExamplePage.tsx
+++ b/NewArch/src/examples/ClipboardExamplePage.tsx
@@ -1,6 +1,6 @@
 'use strict';
 import React, {useState} from 'react';
-import {AccessibilityInfo, Button, Text, TextInput, View} from 'react-native';
+import {Button, Text, TextInput, View} from 'react-native';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
 import Clipboard from '@react-native-clipboard/clipboard';
@@ -10,6 +10,8 @@ export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
     'This text will be copied to the clipboard',
   );
   const [textFromClipboard, setTextFromClipboard] = useState('');
+  const [accessibilityValueCopy, setAccessibilityValueCopy] = useState('');
+  const [accessibilityValuePaste, setAccessibilityValuePaste] = useState('');
   const example1jsx = `<Button
   title="Copy text to the Clipboard"
   onPress={() => Clipboard.setString(textToCopy)}/>`;
@@ -44,18 +46,17 @@ export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
         <View style={{alignItems: 'flex-start', gap: 12}}>
           <Button
             accessibilityLabel="Copy text to the Clipboard"
+            accessibilityValue={{text: accessibilityValueCopy}}
             title="Copy text to the Clipboard"
             onPress={() => {
               Clipboard.setString(textToCopy);
-              AccessibilityInfo.announceForAccessibility(
-                'Text copied to clipboard',
-              );
+              setAccessibilityValueCopy(''); // reset before reading to update on multiple clicks
+              setAccessibilityValueCopy('Text copied to clipboard');
             }}
             onAccessibilityTap={() => {
               Clipboard.setString(textToCopy);
-              AccessibilityInfo.announceForAccessibility(
-                'Text copied to clipboard',
-              );
+              setAccessibilityValueCopy('');
+              setAccessibilityValueCopy('Text copied to clipboard');              
             }}
           />
           <TextInput
@@ -70,18 +71,17 @@ export const ClipboardExamplePage: React.FunctionComponent<{}> = () => {
         <View style={{alignItems: 'flex-start', gap: 12}}>
           <Button
             accessibilityLabel="Paste text from the Clipboard"
+            accessibilityValue={{text: accessibilityValuePaste}}
             title="Paste text from the Clipboard"
             onPress={() => {
               getClipboardText();
-              AccessibilityInfo.announceForAccessibility(
-                'Text pasted from clipboard',
-              );
+              setAccessibilityValuePaste('');
+              setAccessibilityValuePaste('Text pasted from clipboard');             
             }}
             onAccessibilityTap={() => {
               getClipboardText();
-              AccessibilityInfo.announceForAccessibility(
-                'Text pasted from clipboard',
-              );
+              setAccessibilityValuePaste('');
+              setAccessibilityValuePaste('Text pasted from clipboard');
             }}
           />
           <Text>{textFromClipboard}</Text>


### PR DESCRIPTION
## Description

### Why

Repro-Steps:
Launch the React Native Gallery- Experimental app.
Navigate to the 'Expand menu' button and invoke it.
Navigate to 'Home' button and invoke it.
Navigate to 'Clipboard' button and invoke it.
Observe the announcement and behavior.
Actual Result:
On invoking the 'Copy to clipboard' button, Narrator is not announcing any success message.
Note: Visually also no changes appeared on invoking 'Copy to clipboard' button.

Expected Result:
On invoking the 'Copy to clipboard' button, visually the 'Copied' message should appear and Narrator should announce as "Copied to clipboard".

User impact:

Users with visual impairment who rely on screen reader might get confused if narrator does not announce any success message.

MAS Reference: [MAS 4.1.3 – Status Messages](https://aka.ms/MAS4.1.3)

Trap ID: [1.9 - Feedback Failure](https://aka.ms/FeedbackFailure)
Resolves #586 

### What

Implementation of AccessibilityInfo.announceForAccessibility for Fabric is not done yet.

Doing a workaround and using accessibilityValue for now as the functionality is same.
Related PR: https://github.com/microsoft/react-native-windows/pull/14858
Related Issue: https://github.com/microsoft/react-native-gallery/issues/605

## Screenshots

<img width="800" height="728" alt="image" src="https://github.com/user-attachments/assets/330340a7-9fb5-46e5-b0ce-7f272502b2c9" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/621)