### PR TITLE
Revert "[Bug Fix] [React Native New Architecture]: Narrator is not announcing any success message on invoking 'Copy to clipboard' button."

### DIFF
--- a/NewArch/src/examples/ClipboardExamplePage.tsx
+++ b/NewArch/src/examples/ClipboardExamplePage.tsx
@@ -1,6 +1,6 @@
 'use strict';
 import React, {useState} from 'react';
-import {Button, Text, TextInput, View} from 'react-native';
+import {AccessibilityInfo, Button, Text, TextInput, View} from 'react-native';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
 import Clipboard from '@react-native-clipboard/clipboard';
@@ -12,8 +12,6 @@ export const ClipboardExamplePage: React.FunctionComponent<{navigation?: any}> =
     'This text will be copied to the clipboard',
   );
   const [textFromClipboard, setTextFromClipboard] = useState('');
-  const [accessibilityValueCopy, setAccessibilityValueCopy] = useState('');
-  const [accessibilityValuePaste, setAccessibilityValuePaste] = useState('');
   const example1jsx = `<Button
   title="Copy text to the Clipboard"
   onPress={() => Clipboard.setString(textToCopy)}/>`;
@@ -49,25 +47,18 @@ export const ClipboardExamplePage: React.FunctionComponent<{navigation?: any}> =
           <Button
             ref={firstClipboardButtonRef}
             accessibilityLabel="Copy text to the Clipboard"
-            accessibilityValue={{text: accessibilityValueCopy}}
             title="Copy text to the Clipboard"
             onPress={() => {
               Clipboard.setString(textToCopy);
-              // Issue #622: Workaround
-              // AccessibilityInfo.announceForAccessibility(
-              //   'Text copied to clipboard',
-              // );
-              setAccessibilityValueCopy(''); // reset before reading to update on multiple clicks
-              setAccessibilityValueCopy('Text copied to clipboard');
+              AccessibilityInfo.announceForAccessibility(
+                'Text copied to clipboard',
+              );
             }}
             onAccessibilityTap={() => {
               Clipboard.setString(textToCopy);
-              // Issue #622: Workaround
-              // AccessibilityInfo.announceForAccessibility(
-              //   'Text copied to clipboard',
-              // );
-              setAccessibilityValueCopy('');
-              setAccessibilityValueCopy('Text copied to clipboard');              
+              AccessibilityInfo.announceForAccessibility(
+                'Text copied to clipboard',
+              );
             }}
           />
           <TextInput
@@ -82,25 +73,18 @@ export const ClipboardExamplePage: React.FunctionComponent<{navigation?: any}> =
         <View style={{alignItems: 'flex-start', gap: 12}}>
           <Button
             accessibilityLabel="Paste text from the Clipboard"
-            accessibilityValue={{text: accessibilityValuePaste}}
             title="Paste text from the Clipboard"
             onPress={() => {
               getClipboardText();
-              // Issue #622: Workaround
-              // AccessibilityInfo.announceForAccessibility(
-              //   'Text pasted from clipboard',
-              // );
-              setAccessibilityValuePaste('');
-              setAccessibilityValuePaste('Text pasted from clipboard');             
+              AccessibilityInfo.announceForAccessibility(
+                'Text pasted from clipboard',
+              );
             }}
             onAccessibilityTap={() => {
               getClipboardText();
-              // Issue #622: Workaround
-              // AccessibilityInfo.announceForAccessibility(
-              //   'Text pasted from clipboard',
-              // );
-              setAccessibilityValuePaste('');
-              setAccessibilityValuePaste('Text pasted from clipboard');
+              AccessibilityInfo.announceForAccessibility(
+                'Text pasted from clipboard',
+              );
             }}
           />
           <Text>{textFromClipboard}</Text>


### PR DESCRIPTION
Reverts microsoft/react-native-gallery#621

Resolves https://github.com/microsoft/react-native-gallery/issues/622