### PR TITLE
fixing truncation issue on scaling to 200%

### DIFF
--- a/NewArch/src/examples/PressableExamplePage.tsx
+++ b/NewArch/src/examples/PressableExamplePage.tsx
@@ -155,8 +155,10 @@ export const PressableExamplePage: React.FunctionComponent<{navigation?: any}> =
                 : Platform.OS === 'windows'
                 ? PlatformColor('SystemColorButtonFaceColor')
                 : 'silver',
-              width: 140,
-              height: 50,
+              padding: 8,
+              minWidth: 140,
+              alignItems: 'center',
+              justifyContent: 'center',
               borderRadius: 2,
             },
           ]}>
@@ -165,6 +167,7 @@ export const PressableExamplePage: React.FunctionComponent<{navigation?: any}> =
               style={{
                 textAlign: 'center',
                 paddingVertical: 15,
+                flexWrap: 'wrap',
                 color: pressed ? '#FFFFFF' : colors.text,
               }}>
               {pressed ? `Pressed ${timesPressed} times!` : 'Press Me'}

--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -1208,7 +1208,6 @@ exports[`Button Example Page 1`] = `
                 style={
                   [
                     {
-                      "alignItems": "center",
                       "backgroundColor": {
                         "windowsbrush": [
                           "ButtonBackground",
@@ -8600,7 +8599,7 @@ exports[`Expander Example Page 1`] = `
                       undefined,
                     ]
                   }
-                  timeZoneOffsetInSeconds={-0}
+                  timeZoneOffsetInSeconds={19800}
                 />
               </ExpanderView>
             </View>
@@ -26585,7 +26584,6 @@ exports[`Pressable Example Page 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       {
-        "alignItems": "center",
         "backgroundColor": {
           "windowsbrush": [
             "NavigationViewDefaultPaneBackground",
@@ -27732,6 +27730,7 @@ exports[`Pressable Example Page 1`] = `
                 style={
                   [
                     {
+                      "alignItems": "center",
                       "backgroundColor": {
                         "windowsbrush": [
                           "SystemColorButtonFaceColor",

--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -1208,6 +1208,7 @@ exports[`Button Example Page 1`] = `
                 style={
                   [
                     {
+                      "alignItems": "center",
                       "backgroundColor": {
                         "windowsbrush": [
                           "ButtonBackground",

--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -1208,6 +1208,7 @@ exports[`Button Example Page 1`] = `
                 style={
                   [
                     {
+                      "alignItems": "center",
                       "backgroundColor": {
                         "windowsbrush": [
                           "ButtonBackground",
@@ -27736,8 +27737,10 @@ exports[`Pressable Example Page 1`] = `
                         ],
                       },
                       "borderRadius": 2,
-                      "height": 50,
-                      "width": 140,
+                      "justifyContent": "center",
+                      "minWidth": 140,
+                      "padding": 8,
+
                     },
                   ]
                 }
@@ -27746,7 +27749,7 @@ exports[`Pressable Example Page 1`] = `
                   style={
                     {
                       "color": "rgb(28, 28, 30)",
-                      "paddingVertical": 15,
+                      "flexWrap": "wrap",
                       "textAlign": "center",
                     }
                   }
@@ -28445,8 +28448,6 @@ exports[`Pressable Example Page 1`] = `
                       ],
                     },
                     "borderRadius": 2,
-                    "height": 50,
-                    "width": 200,
                   }
                 }
               >
@@ -28454,7 +28455,6 @@ exports[`Pressable Example Page 1`] = `
                   style={
                     {
                       "color": "rgb(28, 28, 30)",
-                      "paddingVertical": 15,
                       "textAlign": "center",
                     }
                   }

--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -1208,7 +1208,6 @@ exports[`Button Example Page 1`] = `
                 style={
                   [
                     {
-                      "alignItems": "center",
                       "backgroundColor": {
                         "windowsbrush": [
                           "ButtonBackground",
@@ -26585,6 +26584,7 @@ exports[`Pressable Example Page 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       {
+        "alignItems": "center",
         "backgroundColor": {
           "windowsbrush": [
             "NavigationViewDefaultPaneBackground",
@@ -27740,7 +27740,6 @@ exports[`Pressable Example Page 1`] = `
                       "justifyContent": "center",
                       "minWidth": 140,
                       "padding": 8,
-
                     },
                   ]
                 }

--- a/__tests__/__snapshots__/App-test.js.snap
+++ b/__tests__/__snapshots__/App-test.js.snap
@@ -8599,7 +8599,7 @@ exports[`Expander Example Page 1`] = `
                       undefined,
                     ]
                   }
-                  timeZoneOffsetInSeconds={19800}
+                  timeZoneOffsetInSeconds={-0}
                 />
               </ExpanderView>
             </View>

--- a/src/examples/PressableExamplePage.tsx
+++ b/src/examples/PressableExamplePage.tsx
@@ -143,17 +143,19 @@ export const PressableExamplePage: React.FunctionComponent<{}> = () => {
                 : Platform.OS === 'windows'
                 ? PlatformColor('SystemColorButtonFaceColor')
                 : 'silver',
-              width: 140,
-              height: 50,
               borderRadius: 2,
+              padding: 8,
+              minWidth: 140,
+              alignItems: 'center',
+              justifyContent: 'center',
             },
           ]}>
           {({pressed}) => (
             <Text
               style={{
                 textAlign: 'center',
-                paddingVertical: 15,
                 color: pressed ? '#FFFFFF' : colors.text,
+                flexWrap: 'wrap',
               }}>
               {pressed ? `Pressed ${timesPressed} times!` : 'Press Me'}
             </Text>
@@ -170,8 +172,6 @@ export const PressableExamplePage: React.FunctionComponent<{}> = () => {
             'click me to see the diffrent events (press, pressIn, pressOut, longPress)'
           }
           style={{
-            width: 200,
-            height: 50,
             borderRadius: 2,
             backgroundColor:
               Platform.OS === 'windows'
@@ -185,7 +185,6 @@ export const PressableExamplePage: React.FunctionComponent<{}> = () => {
           <Text
             style={{
               textAlign: 'center',
-              paddingVertical: 15,
               color: colors.text,
             }}>
             Most recent event: {currEvent}


### PR DESCRIPTION
## Description

Success information text i.e., "Pressed 'X' times!" is getting truncated after applying text scaling to 200%. Fixes in both paper and fabric

### Why

Success information text i.e., "Pressed 'X' times!" is getting truncated after applying text scaling to 200%

Resolves [https://github.com/microsoft/react-native-gallery/issues/606]

### What
Success information text i.e., "Pressed 'X' times!" is getting truncated after applying text scaling to 200%


## Screenshots

Before this change

https://github.com/user-attachments/assets/a93b2f09-de12-4d6d-b5e4-3e2371abaa95

After this change


https://github.com/user-attachments/assets/ed5a02ce-7c32-4912-bbf0-0bccb3d84590


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/640)