### PR TITLE
adding accessibilityLabel for navitor button

### DIFF
--- a/NewArch/src/App.tsx
+++ b/NewArch/src/App.tsx
@@ -317,62 +317,78 @@ function CustomDrawerContent({ navigation }: { navigation: any }) {
     }
   };
 
-  if (!isDrawerOpen) return <View />;
+  // Always render the hamburger button, but conditionally render drawer content
+  return (
+    <View style={styles.drawer}>
+      <Pressable
+        ref={hamburgerRef}
+        accessibilityRole="button"
+        accessibilityLabel="Navigation menu"
+        accessibilityState={{ expanded: isDrawerOpen }}
+        accessibilityHint={isDrawerOpen ? "Tap to collapse navigation menu" : "Tap to expand navigation menu"}
+        style={styles.menu}
+        onPress={() => {
+          if (isDrawerOpen) {
+            navigation.closeDrawer();
+          } else {
+            navigation.openDrawer();
+          }
+        }}
+        onAccessibilityTap={() => {
+          if (isDrawerOpen) {
+            navigation.closeDrawer();
+          } else {
+            navigation.openDrawer();
+          }
+        }}
+        onKeyDown={onHamburgerKeyDown}
+        keyboardEvents={['keyDown']}
+        focusable={true}>
+        <Text style={styles.icon}>&#xE700;</Text>
+      </Pressable>
+      
+      {isDrawerOpen && (
+        <>
+          <DrawerListItem
+            ref={homeRef}
+            route="Home"
+            label="Home"
+            icon="&#xE80F;"
+            navigation={navigation}
+            currentRoute={currentRoute}
+            onKeyDown={() => {}}
+            keyboardEvents={['keyDown']}
+            focusable={true}
+          />
+          <DrawerListItem
+            route="All samples"
+            label="All samples"
+            icon="&#xE71D;"
+            navigation={navigation}
+            currentRoute={currentRoute}
+            keyboardEvents={['keyDown']}
+            focusable={true}
+          />
 
+          <View style={styles.drawerDivider} />
+          <DrawerListView navigation={navigation} currentRoute={currentRoute} />
+          <View style={styles.drawerDivider} />
 
-return (
-  <View style={styles.drawer}>
-    <Pressable
-      ref={hamburgerRef}
-      accessibilityRole="button"
-      accessibilityLabel="Navigation bar expanded"
-      tooltip="Collapse Menu"
-      style={styles.menu}
-      onPress={() => navigation.closeDrawer()}
-      onAccessibilityTap={() => navigation.closeDrawer()}
-      onKeyDown={onHamburgerKeyDown}
-      keyboardEvents={['keyDown']}
-      focusable={true}>
-      <Text style={styles.icon}>&#xE700;</Text>
-    </Pressable>
-    <DrawerListItem
-      ref={homeRef}
-      route="Home"
-      label="Home"
-      icon="&#xE80F;"
-      navigation={navigation}
-      currentRoute={currentRoute}
-      onKeyDown={() => {}}
-      keyboardEvents={['keyDown']}    // <-- Added this for consistent keyboard handling
-      focusable={true}
-    />
-    <DrawerListItem
-      route="All samples"
-      label="All samples"
-      icon="&#xE71D;"
-      navigation={navigation}
-      currentRoute={currentRoute}
-      keyboardEvents={['keyDown']}    // Optional, for consistent behavior
-      focusable={true}
-    />
-
-    <View style={styles.drawerDivider} />
-      <DrawerListView navigation={navigation} currentRoute={currentRoute} />
-    <View style={styles.drawerDivider} />
-
-    <DrawerListItem
-      ref={settingsRef}
-      route="Settings"
-      label="Settings"
-      icon="&#xE713;"
-      navigation={navigation}
-      currentRoute={currentRoute}
-      onKeyDown={onSettingsKeyDown}
-      keyboardEvents={['keyDown']}
-      focusable={true}
-    />
-  </View>
-);
+          <DrawerListItem
+            ref={settingsRef}
+            route="Settings"
+            label="Settings"
+            icon="&#xE713;"
+            navigation={navigation}
+            currentRoute={currentRoute}
+            onKeyDown={onSettingsKeyDown}
+            keyboardEvents={['keyDown']}
+            focusable={true}
+          />
+        </>
+      )}
+    </View>
+  );
 }
 
 const Drawer = createDrawerNavigator();

--- a/NewArch/src/components/ScreenWrapper.tsx
+++ b/NewArch/src/components/ScreenWrapper.tsx
@@ -8,7 +8,7 @@ import {
   Pressable,
   useColorScheme,
 } from 'react-native';
-import {useNavigation, DrawerActions} from '../Navigation';
+import {useNavigation, DrawerActions, getDrawerStatusFromState} from '../Navigation';
 
 const createStyles = () =>
   StyleSheet.create({
@@ -60,36 +60,32 @@ export function ScreenWrapper({
 }: ScreenWrapperProps): JSX.Element {
   const navigation = useNavigation();
   const colorScheme = useColorScheme();
-  const styles = createStyles(colorScheme);
+  const styles = createStyles();
+  
+  const isDrawerOpen = getDrawerStatusFromState(navigation.getState()) === 'open';
 
   return (
     <View style={styles.container}>
       <Pressable
         accessibilityRole="button"
-        accessibilityLabel="Navigation bar"
-        // requires react-native-gesture-handler to be imported in order to pass testing.
-        // blocked by #125
-        /*accessibilityState={{
-          expanded: useIsDrawerOpen(),
-        }}*/
+        accessibilityLabel="Navigation menu"
+        accessibilityState={{ expanded: isDrawerOpen }}
+        accessibilityHint={isDrawerOpen ? 'Tap to collapse navigation menu' : 'Tap to expand navigation menu'}
         style={styles.navBar}
         onPress={() => {
-          navigation.dispatch(DrawerActions.openDrawer());
+          navigation.dispatch(DrawerActions.toggleDrawer());
         }}>
         <View>
           <TouchableHighlight
             accessibilityRole="button"
-            accessibilityLabel="Navigation bar hamburger icon"
-            {...{tooltip: 'Expand Menu'}}
-            // requires react-native-gesture-handler to be imported in order to pass testing.
-            // blocked by #125
-            //accessibilityState={{expanded: useIsDrawerOpen()}}
+            accessibilityLabel="Navigation menu"
+            accessibilityState={{ expanded: isDrawerOpen }}
             style={styles.menu}
-            onPress={() => navigation.dispatch(DrawerActions.openDrawer())}
-            onAccessibilityTap={() => navigation.dispatch(DrawerActions.openDrawer())}
+            onPress={() => navigation.dispatch(DrawerActions.toggleDrawer())}
+            onAccessibilityTap={() => navigation.dispatch(DrawerActions.toggleDrawer())}
             activeOpacity={0.5783}
             underlayColor="rgba(0, 0, 0, 0.0241);">
-            <Text style={styles.icon} accessibilityLabel="Navigation bar hamburger icon text">&#xE700;</Text>
+            <Text style={styles.icon}>&#xE700;</Text>
           </TouchableHighlight>
         </View>
       </Pressable>


### PR DESCRIPTION
## Description

Screen reader fails to announce the expand/collapse state of the navigation

### Why
Screen reader fails to announce the expand/collapse state of the navigation

Resolves [https://github.com/microsoft/react-native-gallery/issues/612]

### What

Screen reader fails to announce the expand/collapse state of the navigation

## Screenshots
Before changes

https://github.com/user-attachments/assets/4db312c4-37cf-46bb-bede-f70ffc1c1410

After changes

https://github.com/user-attachments/assets/60080cc3-d9a4-456f-bedd-f53998f15ced


