### PR TITLE
adding accessibility label for navihator button

### DIFF
--- a/NewArch/src/App.tsx
+++ b/NewArch/src/App.tsx
@@ -328,62 +328,76 @@ function CustomDrawerContent({ navigation }: { navigation: any }) {
     }
   };
 
-  if (!isDrawerOpen) return <View />;
+  return (
+    <View style={styles.drawer}>
+      <Pressable
+        ref={hamburgerRef}
+        accessibilityRole="button"
+        accessibilityLabel="Navigation menu"
+        accessibilityState={{ expanded: isDrawerOpen }}
+        accessibilityHint={isDrawerOpen ? 'Tap to collapse navigation menu' : 'Tap to expand navigation menu'}
+        style={styles.menu}
+        onPress={() => {
+          if (isDrawerOpen) {
+            navigation.closeDrawer();
+          } else {
+            navigation.openDrawer();
+          }
+        }}
+        onAccessibilityTap={() => {
+          if (isDrawerOpen) {
+            navigation.closeDrawer();
+          } else {
+            navigation.openDrawer();
+          }
+        }}
+         onKeyDown={onHamburgerKeyDown}
+        keyboardEvents={['keyDown']}
+        focusable={true}>
+        <Text style={styles.icon}>&#xE700;</Text>
+      </Pressable>
 
+      {isDrawerOpen && (
+        <>
+          <DrawerListItem
+            ref={homeRef}
+            route="Home"
+            label="Home"
+            icon="&#xE80F;"
+            navigation={navigation}
+            currentRoute={currentRoute}
+            onKeyDown={() => {}}
+            keyboardEvents={['keyDown']}
+            focusable={true}
+          />
+          <DrawerListItem
+            route="All samples"
+            label="All samples"
+            icon="&#xE71D;"
+            navigation={navigation}
+            currentRoute={currentRoute}
+            keyboardEvents={['keyDown']}
+            focusable={true}
+          />
+          <View style={styles.drawerDivider} />
+          <DrawerListView navigation={navigation} currentRoute={currentRoute} />
+          <View style={styles.drawerDivider} />
 
-return (
-  <View style={styles.drawer}>
-    <Pressable
-      ref={hamburgerRef}
-      accessibilityRole="button"
-      accessibilityLabel="Navigation bar expanded"
-      tooltip="Collapse Menu"
-      style={styles.menu}
-      onPress={() => navigation.closeDrawer()}
-      onAccessibilityTap={() => navigation.closeDrawer()}
-      onKeyDown={onHamburgerKeyDown}
-      keyboardEvents={['keyDown']}
-      focusable={true}>
-      <Text style={styles.icon}>&#xE700;</Text>
-    </Pressable>
-    <DrawerListItem
-      ref={homeRef}
-      route="Home"
-      label="Home"
-      icon="&#xE80F;"
-      navigation={navigation}
-      currentRoute={currentRoute}
-      onKeyDown={() => {}}
-      keyboardEvents={['keyDown']}    // <-- Added this for consistent keyboard handling
-      focusable={true}
-    />
-    <DrawerListItem
-      route="All samples"
-      label="All samples"
-      icon="&#xE71D;"
-      navigation={navigation}
-      currentRoute={currentRoute}
-      keyboardEvents={['keyDown']}    // Optional, for consistent behavior
-      focusable={true}
-    />
-
-    <View style={styles.drawerDivider} />
-      <DrawerListView navigation={navigation} currentRoute={currentRoute} />
-    <View style={styles.drawerDivider} />
-
-    <DrawerListItem
-      ref={settingsRef}
-      route="Settings"
-      label="Settings"
-      icon="&#xE713;"
-      navigation={navigation}
-      currentRoute={currentRoute}
-      onKeyDown={onSettingsKeyDown}
-      keyboardEvents={['keyDown']}
-      focusable={true}
-    />
-  </View>
-);
+          <DrawerListItem
+            ref={settingsRef}
+            route="Settings"
+            label="Settings"
+            icon="&#xE713;"
+            navigation={navigation}
+            currentRoute={currentRoute}
+            onKeyDown={onSettingsKeyDown}
+            keyboardEvents={['keyDown']}
+            focusable={true}
+          />
+        </>
+      )}
+    </View>
+  );
 }
 
 const Drawer = createDrawerNavigator();

--- a/NewArch/src/components/ScreenWrapper.tsx
+++ b/NewArch/src/components/ScreenWrapper.tsx
@@ -6,9 +6,8 @@ import {
   Text,
   PlatformColor,
   Pressable,
-  useColorScheme,
 } from 'react-native';
-import {useNavigation, DrawerActions} from '../Navigation';
+import {useNavigation, DrawerActions, getDrawerStatusFromState} from '../Navigation';
 
 const createStyles = () =>
   StyleSheet.create({
@@ -59,14 +58,16 @@ export function ScreenWrapper({
   doNotInset,
 }: ScreenWrapperProps): JSX.Element {
   const navigation = useNavigation();
-  const colorScheme = useColorScheme();
-  const styles = createStyles(colorScheme);
+  const styles = createStyles();
+  const isDrawerOpen = getDrawerStatusFromState(navigation.getState()) === 'open';
 
   return (
     <View style={styles.container}>
       <Pressable
         accessibilityRole="button"
         accessibilityLabel="Navigation bar"
+        accessibilityState={{ expanded: isDrawerOpen }}
+        accessibilityHint={isDrawerOpen ? 'Tap to collapse navigation menu' : 'Tap to expand navigation menu'}
         // requires react-native-gesture-handler to be imported in order to pass testing.
         // blocked by #125
         /*accessibilityState={{
@@ -74,19 +75,19 @@ export function ScreenWrapper({
         }}*/
         style={styles.navBar}
         onPress={() => {
-          navigation.dispatch(DrawerActions.openDrawer());
+          navigation.dispatch(DrawerActions.toggleDrawer());
         }}>
         <View>
           <TouchableHighlight
             accessibilityRole="button"
-            accessibilityLabel="Navigation bar hamburger icon"
-            {...{tooltip: 'Expand Menu'}}
+            accessibilityLabel="Navigation menu"
+            accessibilityState={{ expanded: isDrawerOpen }}
             // requires react-native-gesture-handler to be imported in order to pass testing.
             // blocked by #125
             //accessibilityState={{expanded: useIsDrawerOpen()}}
             style={styles.menu}
-            onPress={() => navigation.dispatch(DrawerActions.openDrawer())}
-            onAccessibilityTap={() => navigation.dispatch(DrawerActions.openDrawer())}
+            onPress={() => navigation.dispatch(DrawerActions.toggleDrawer())}
+            onAccessibilityTap={() => navigation.dispatch(DrawerActions.toggleDrawer())}
             activeOpacity={0.5783}
             underlayColor="rgba(0, 0, 0, 0.0241);">
             <Text style={styles.icon} accessibilityLabel="Navigation bar hamburger icon text">&#xE700;</Text>


### PR DESCRIPTION
## Description

Screen reader fails to announce the expand/collapse state of the navigation

### Why
Screen reader fails to announce the expand/collapse state of the navigation

Resolves [https://github.com/microsoft/react-native-gallery/issues/612]

### What

Screen reader fails to announce the expand/collapse state of the navigation

## Screenshots
Before changes


https://github.com/user-attachments/assets/59958af6-6be1-4e2b-aea8-2dc10e3cc3c4



After changes


https://github.com/user-attachments/assets/824baad8-5af8-4c20-a005-57efbb2c4df6





 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/643)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/647)