### PR TITLE
Fix for Color contrast ratio for the 'This is a modal with more complex styling' text does not meet the minimum required ratio 4.5:1.

### DIFF
--- a/NewArch/src/examples/ModalExamplePage.tsx
+++ b/NewArch/src/examples/ModalExamplePage.tsx
@@ -213,6 +213,7 @@ const styles = StyleSheet.create({
   },
   modalView: {
     margin: 20,
+    backgroundColor: PlatformColor('ControlFillColorDefaultBrush'),
     borderRadius: 20,
     padding: 35,
     alignItems: 'center',
@@ -232,7 +233,7 @@ const styles = StyleSheet.create({
     elevation: 2,
   },
   textStyle: {
-    color: 'white',
+    color: PlatformColor('TextControlForeground'),
     fontWeight: 'bold',
     textAlign: 'center',
     paddingTop: 5,


### PR DESCRIPTION
## Description

### Why
Modal text used hard-coded white color that failed WCAG 4.5:1 contrast requirements and was invisible in Windows High Contrast mode, creating accessibility barriers for users with visual impairments.

Resolves : Modal accessibility compliance issue.

### What
Replaced [color: 'white'] with [PlatformColor('TextControlForeground')]in textStyle
Ensured proper background/foreground color pairing using Windows system colors
Changes ensure Modal automatically adapts to Windows accessibility modes while meeting WCAG contrast standards.
## Screenshots
Before
<img width="845" height="479" alt="before" src="https://github.com/user-attachments/assets/ccd74600-9686-4132-a218-fdd8049867a1" />

After
<img width="852" height="475" alt="After" src="https://github.com/user-attachments/assets/753552d2-c19c-4a0b-8699-d07054e55962" />

Add any relevant screen captures here from before or after your changes.
