### PR TITLE
Fix for git issue 657 and 658 , Narrator not picking up state changes for VirtualizedList  'Selection Support Pressable' button.

### DIFF
--- a/NewArch/src/examples/VirtualizedListExamplePage.tsx
+++ b/NewArch/src/examples/VirtualizedListExamplePage.tsx
@@ -373,6 +373,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
             <Pressable
               accessibilityRole="button"
               accessibilityLabel={'selection support pressable'}
+              accessibilityValue={{text: selectedSupport}}
               accessibilityHint={'click me to change selection support'}
               onPress={() => {
                 if (selectedSupport === 'Single') {


### PR DESCRIPTION
## Description
Fixed VirtualizedList accessibility issue where screen readers failed to announce the current/update selection state when navigating to the 'Selection Support Pressable' button via keyboard.

Resolves : Narrator call for button state or updated state narration.
### What
Single line fix: Added accessibilityValue={{text: selectedSupport} to the Pressable component.
Screen readers now announce current selection mode ("Multiple" or "Single") when tabbing to the button
Provides proper state information to Windows UI Automation framework
Improves accessibility compliance for keyboard navigation users



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/659)