### PR TITLE
adding changes to support horizontal scroll with keyboard

### DIFF
--- a/NewArch/src/examples/ScrollViewExample.tsx
+++ b/NewArch/src/examples/ScrollViewExample.tsx
@@ -169,11 +169,7 @@ export const ScrollViewExamplePage: React.FunctionComponent<{navigation?: any}> 
     ref={horizontalScrollViewRef}
     style={{height: 40, borderWidth: 1, borderColor: 'gray'}} 
     horizontal={true}
-    onKeyDown={(e) => {
-      const windowWidth = Dimensions.get('window').width;
-      const scrollAmount = windowWidth * 0.1; // 10% of window width
-      // Handle arrow key navigation...
-    }}
+    onKeyDown={handleHorizontalScrollViewKeyDown}
     keyboardEvents={['keyDown']}
     focusable={true}
     onScroll={(event) => setScrollOffset(event.nativeEvent.contentOffset.x)}


### PR DESCRIPTION
## Description
[React Native Gallery Preview]: User is unable to access the 'A Horizontal Scrollview scroll bar using keyboard

### Why

[React Native Gallery Preview]: User is unable to access the 'A Horizontal Scrollview scroll bar using keyboard


Resolves [https://github.com/https://github.com/microsoft/react-native-gallery/issues/651]

### What

[React Native Gallery Preview]: User is unable to access the 'A Horizontal Scrollview scroll bar using keyboard


## Screenshots
Before

https://github.com/user-attachments/assets/b484294f-8771-4487-aad3-6f95eba7c624

After

https://github.com/user-attachments/assets/5a2e0ce4-fd05-45c1-96d4-f1acb43d508e


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/660)