### PR TITLE
adding changes to support voice command to display virtualized list numbers

### DIFF
--- a/NewArch/src/examples/VirtualizedListExamplePage.tsx
+++ b/NewArch/src/examples/VirtualizedListExamplePage.tsx
@@ -232,6 +232,9 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         style={styles.item}
         onPress={() => {
           setSelectedIndex(item.index);
+        }}
+        onAccessibilityTap={() => {
+          setSelectedIndex(item.index);
         }}>
         <Text style={styles.title}>{item.title}</Text>
       </TouchableHighlight>
@@ -249,6 +252,9 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         activeOpacity={0.6}
         underlayColor={colors.border}
         onPress={() => {
+          setSelectedIndex(item.index);
+        }}
+        onAccessibilityTap={() => {
           setSelectedIndex(item.index);
         }}>
         <Text style={styles.title}>{item.title}</Text>
@@ -290,6 +296,9 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         underlayColor={colors.border}
         onPress={() => {
           setSelectedIndex2(item.index);
+        }}
+        onAccessibilityTap={() => {
+          setSelectedIndex(item.index);
         }}>
         <Text style={styles.title}>{item.title}</Text>
       </TouchableHighlight>
@@ -317,8 +326,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
           <View
             ref={firstVirtualizedListRef}
             style={styles.container}
-            accessibilityLabel="VirtualizedList container"
-            accessible={true}>
+            accessibilityLabel="VirtualizedList container">
             <VirtualizedList
               accessibilityRole="list"
               data={DATA}
@@ -329,7 +337,6 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
               getItem={getItem}
               accessibilityLabel={'A simple VirtualizedList'}
               focusable={true}
-              accessible={true}
             />
           </View>
         </ScrollView>
@@ -339,7 +346,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         title="A VirtualizedList with single selection support"
         code={example2jsx}>
         <ScrollView horizontal={true}>
-          <View style={styles.container} accessible={true}>
+          <View style={styles.container}>
             <VirtualizedList
               accessibilityRole="list"
               data={DATA}
@@ -352,7 +359,6 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
                 'A VirtualizedList with single selection support'
               }
               focusable={true}
-              accessible={true}
             />
           </View>
         </ScrollView>

--- a/NewArch/src/examples/VirtualizedListExamplePage.tsx
+++ b/NewArch/src/examples/VirtualizedListExamplePage.tsx
@@ -218,8 +218,20 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
   const renderItem = ({item}) => {
     return (
       <TouchableHighlight
-        accessibilityRole="listitem"
+        accessibilityRole="button"
         accessibilityLabel={item.title}
+        accessibilityHint={`Select ${item.title}`}
+        accessibilityActions={[
+          { name: 'activate', label: 'Select' },
+        ]}
+        onAccessibilityAction={(event) => {
+          if (event.nativeEvent.actionName === 'activate') {
+            setSelectedIndex(item.index);
+          }
+        }}
+        importantForAccessibility="yes"
+        focusable={true}
+        accessible={true}
         style={styles.item}
         onPress={() => {
           setSelectedIndex(item.index);
@@ -227,7 +239,12 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         onAccessibilityTap={() => {
           setSelectedIndex(item.index);
         }}>
-        <Text style={styles.title}>{item.title}</Text>
+        <Text 
+          style={styles.title}
+          importantForAccessibility="no-hide-descendants"
+          accessible={false}>
+          {item.title}
+        </Text>
       </TouchableHighlight>
     );
   };
@@ -235,8 +252,20 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
   const renderItem2 = ({item}) => {
     return (
       <TouchableHighlight
-        accessibilityRole="listitem"
+        accessibilityRole="button"
         accessibilityLabel={item.title}
+        accessibilityHint={`Select ${item.title}`}
+        accessibilityActions={[
+          { name: 'activate', label: 'Select' },
+        ]}
+        onAccessibilityAction={(event) => {
+          if (event.nativeEvent.actionName === 'activate') {
+            setSelectedIndex(item.index);
+          }
+        }}
+        importantForAccessibility="yes"
+        focusable={true}
+        accessible={true}
         style={item.index === selectedIndex ? styles.itemSelected : styles.item}
         activeOpacity={0.6}
         underlayColor={colors.border}
@@ -246,7 +275,12 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         onAccessibilityTap={() => {
           setSelectedIndex(item.index);
         }}>
-        <Text style={styles.title}>{item.title}</Text>
+        <Text 
+          style={styles.title}
+          importantForAccessibility="no-hide-descendants"
+          accessible={false}>
+          {item.title}
+        </Text>
       </TouchableHighlight>
     );
   };
@@ -254,8 +288,24 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
   const renderItem3 = ({item}) => {
     return selectedSupport === 'Multiple' ? (
       <TouchableHighlight
-        accessibilityRole="listitem"
+        accessibilityRole="button"
         accessibilityLabel={item.title}
+        accessibilityHint={`Toggle selection for ${item.title}`}
+        accessibilityActions={[
+          { name: 'activate', label: 'Toggle' },
+        ]}
+        onAccessibilityAction={(event) => {
+          if (event.nativeEvent.actionName === 'activate') {
+            if (getList.includes(item.index)) {
+              setList(getList.filter((value) => value !== item.index));
+            } else {
+              setList(getList.concat([item.index]));
+            }
+          }
+        }}
+        importantForAccessibility="yes"
+        focusable={true}
+        accessible={true}
         style={getList.includes(item.index) ? styles.itemSelected : styles.item}
         activeOpacity={0.6}
         underlayColor={colors.border}
@@ -267,13 +317,30 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
           }
         }}>
         <View style={styles.item}>
-          <Text style={styles.title}>{item.title}</Text>
+          <Text 
+            style={styles.title}
+            importantForAccessibility="no-hide-descendants"
+            accessible={false}>
+            {item.title}
+          </Text>
         </View>
       </TouchableHighlight>
     ) : (
       <TouchableHighlight
-        accessibilityRole="listitem"
+        accessibilityRole="button"
         accessibilityLabel={item.title}
+        accessibilityHint={`Select ${item.title}`}
+        accessibilityActions={[
+          { name: 'activate', label: 'Select' },
+        ]}
+        onAccessibilityAction={(event) => {
+          if (event.nativeEvent.actionName === 'activate') {
+            setSelectedIndex2(item.index);
+          }
+        }}
+        importantForAccessibility="yes"
+        focusable={true}
+        accessible={true}
         style={
           item.index === selectedIndex2 ? styles.itemSelected : styles.item
         }
@@ -285,7 +352,12 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         onAccessibilityTap={() => {
           setSelectedIndex2(item.index);
         }}>
-        <Text style={styles.title}>{item.title}</Text>
+        <Text 
+          style={styles.title}
+          importantForAccessibility="no-hide-descendants"
+          accessible={false}>
+          {item.title}
+        </Text>
       </TouchableHighlight>
     );
   };
@@ -311,9 +383,9 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
           <View
             ref={firstVirtualizedListRef}
             style={styles.container}
-            accessibilityLabel="VirtualizedList container">
+            accessibilityLabel="VirtualizedList container"
+            accessibilityRole="list">
             <VirtualizedList
-              accessibilityRole="list"
               data={DATA}
               initialNumToRender={10}
               renderItem={renderItem}
@@ -322,6 +394,8 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
               getItem={getItem}
               accessibilityLabel={'A simple VirtualizedList'}
               focusable={true}
+              accessible={true}
+              importantForAccessibility="yes"
             />
           </View>
         </ScrollView>
@@ -331,9 +405,8 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         title="A VirtualizedList with single selection support"
         code={example2jsx}>
         <ScrollView horizontal={true}>
-          <View style={styles.container}>
+          <View style={styles.container} accessibilityRole="list">
             <VirtualizedList
-              accessibilityRole="list"
               data={DATA}
               initialNumToRender={10}
               renderItem={renderItem2}
@@ -344,6 +417,8 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
                 'A VirtualizedList with single selection support'
               }
               focusable={true}
+              accessible={true}
+              importantForAccessibility="yes"
             />
           </View>
         </ScrollView>
@@ -353,9 +428,8 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         title="A VirtualizedList with multiple selection support."
         code={example3jsx}>
         <ScrollView horizontal={true}>
-          <View style={styles.container}>
+          <View style={styles.container} accessibilityRole="list">
             <VirtualizedList
-              accessibilityRole="list"
               data={DATA}
               initialNumToRender={10}
               renderItem={renderItem3}
@@ -366,6 +440,8 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
                 'A VirtualizedList with multiple selection support'
               }
               focusable={true}
+              accessible={true}
+              importantForAccessibility="yes"
             />
           </View>
           <View style={styles.selectionContainer}>

--- a/NewArch/src/examples/VirtualizedListExamplePage.tsx
+++ b/NewArch/src/examples/VirtualizedListExamplePage.tsx
@@ -26,7 +26,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
     if (firstVirtualizedListRef?.current) {
       firstVirtualizedListRef.current.focus();
     }
-  }, []);
+  }, [firstVirtualizedListRef]);
 
   const example1jsx = `
   var DATA: INT[] = [];

--- a/NewArch/src/examples/VirtualizedListExamplePage.tsx
+++ b/NewArch/src/examples/VirtualizedListExamplePage.tsx
@@ -41,7 +41,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
     </TouchableHighlight>
   );
 
-  <VirtualizedList that's like just make sure
+  <VirtualizedList
     data={DATA}
     initialNumToRender={30}
     renderItem={renderItem}

--- a/NewArch/src/examples/VirtualizedListExamplePage.tsx
+++ b/NewArch/src/examples/VirtualizedListExamplePage.tsx
@@ -218,33 +218,14 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
   const renderItem = ({item}) => {
     return (
       <TouchableHighlight
-        accessibilityRole="button"
         accessibilityLabel={item.title}
-        accessibilityHint={`Select ${item.title}`}
-        accessibilityActions={[
-          { name: 'activate', label: 'Select' },
-        ]}
-        onAccessibilityAction={(event) => {
-          if (event.nativeEvent.actionName === 'activate') {
-            setSelectedIndex(item.index);
-          }
-        }}
-        importantForAccessibility="yes"
-        focusable={true}
         accessible={true}
+        focusable={true}
         style={styles.item}
         onPress={() => {
           setSelectedIndex(item.index);
-        }}
-        onAccessibilityTap={() => {
-          setSelectedIndex(item.index);
         }}>
-        <Text 
-          style={styles.title}
-          importantForAccessibility="no-hide-descendants"
-          accessible={false}>
-          {item.title}
-        </Text>
+        <Text style={styles.title}>{item.title}</Text>
       </TouchableHighlight>
     );
   };
@@ -252,35 +233,16 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
   const renderItem2 = ({item}) => {
     return (
       <TouchableHighlight
-        accessibilityRole="button"
         accessibilityLabel={item.title}
-        accessibilityHint={`Select ${item.title}`}
-        accessibilityActions={[
-          { name: 'activate', label: 'Select' },
-        ]}
-        onAccessibilityAction={(event) => {
-          if (event.nativeEvent.actionName === 'activate') {
-            setSelectedIndex(item.index);
-          }
-        }}
-        importantForAccessibility="yes"
-        focusable={true}
         accessible={true}
+        focusable={true}
         style={item.index === selectedIndex ? styles.itemSelected : styles.item}
         activeOpacity={0.6}
         underlayColor={colors.border}
         onPress={() => {
           setSelectedIndex(item.index);
-        }}
-        onAccessibilityTap={() => {
-          setSelectedIndex(item.index);
         }}>
-        <Text 
-          style={styles.title}
-          importantForAccessibility="no-hide-descendants"
-          accessible={false}>
-          {item.title}
-        </Text>
+        <Text style={styles.title}>{item.title}</Text>
       </TouchableHighlight>
     );
   };
@@ -288,24 +250,9 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
   const renderItem3 = ({item}) => {
     return selectedSupport === 'Multiple' ? (
       <TouchableHighlight
-        accessibilityRole="button"
         accessibilityLabel={item.title}
-        accessibilityHint={`Toggle selection for ${item.title}`}
-        accessibilityActions={[
-          { name: 'activate', label: 'Toggle' },
-        ]}
-        onAccessibilityAction={(event) => {
-          if (event.nativeEvent.actionName === 'activate') {
-            if (getList.includes(item.index)) {
-              setList(getList.filter((value) => value !== item.index));
-            } else {
-              setList(getList.concat([item.index]));
-            }
-          }
-        }}
-        importantForAccessibility="yes"
-        focusable={true}
         accessible={true}
+        focusable={true}
         style={getList.includes(item.index) ? styles.itemSelected : styles.item}
         activeOpacity={0.6}
         underlayColor={colors.border}
@@ -317,30 +264,14 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
           }
         }}>
         <View style={styles.item}>
-          <Text 
-            style={styles.title}
-            importantForAccessibility="no-hide-descendants"
-            accessible={false}>
-            {item.title}
-          </Text>
+          <Text style={styles.title}>{item.title}</Text>
         </View>
       </TouchableHighlight>
     ) : (
       <TouchableHighlight
-        accessibilityRole="button"
         accessibilityLabel={item.title}
-        accessibilityHint={`Select ${item.title}`}
-        accessibilityActions={[
-          { name: 'activate', label: 'Select' },
-        ]}
-        onAccessibilityAction={(event) => {
-          if (event.nativeEvent.actionName === 'activate') {
-            setSelectedIndex2(item.index);
-          }
-        }}
-        importantForAccessibility="yes"
-        focusable={true}
         accessible={true}
+        focusable={true}
         style={
           item.index === selectedIndex2 ? styles.itemSelected : styles.item
         }
@@ -348,16 +279,8 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         underlayColor={colors.border}
         onPress={() => {
           setSelectedIndex2(item.index);
-        }}
-        onAccessibilityTap={() => {
-          setSelectedIndex2(item.index);
         }}>
-        <Text 
-          style={styles.title}
-          importantForAccessibility="no-hide-descendants"
-          accessible={false}>
-          {item.title}
-        </Text>
+        <Text style={styles.title}>{item.title}</Text>
       </TouchableHighlight>
     );
   };
@@ -383,8 +306,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
           <View
             ref={firstVirtualizedListRef}
             style={styles.container}
-            accessibilityLabel="VirtualizedList container"
-            accessibilityRole="list">
+            accessibilityLabel="VirtualizedList container">
             <VirtualizedList
               data={DATA}
               initialNumToRender={10}
@@ -394,8 +316,6 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
               getItem={getItem}
               accessibilityLabel={'A simple VirtualizedList'}
               focusable={true}
-              accessible={true}
-              importantForAccessibility="yes"
             />
           </View>
         </ScrollView>
@@ -405,7 +325,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         title="A VirtualizedList with single selection support"
         code={example2jsx}>
         <ScrollView horizontal={true}>
-          <View style={styles.container} accessibilityRole="list">
+          <View style={styles.container}>
             <VirtualizedList
               data={DATA}
               initialNumToRender={10}
@@ -417,8 +337,6 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
                 'A VirtualizedList with single selection support'
               }
               focusable={true}
-              accessible={true}
-              importantForAccessibility="yes"
             />
           </View>
         </ScrollView>
@@ -428,7 +346,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         title="A VirtualizedList with multiple selection support."
         code={example3jsx}>
         <ScrollView horizontal={true}>
-          <View style={styles.container} accessibilityRole="list">
+          <View style={styles.container}>
             <VirtualizedList
               data={DATA}
               initialNumToRender={10}
@@ -440,8 +358,6 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
                 'A VirtualizedList with multiple selection support'
               }
               focusable={true}
-              accessible={true}
-              importantForAccessibility="yes"
             />
           </View>
           <View style={styles.selectionContainer}>

--- a/NewArch/src/examples/VirtualizedListExamplePage.tsx
+++ b/NewArch/src/examples/VirtualizedListExamplePage.tsx
@@ -9,7 +9,7 @@ import {
   PlatformColor,
   Pressable,
 } from 'react-native';
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
 // import CheckBox from '@react-native-community/checkbox';
@@ -20,6 +20,13 @@ import {usePageFocusManagement} from '../hooks/usePageFocusManagement';
 export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: any}> = ({navigation}) => {
   const firstVirtualizedListRef = usePageFocusManagement(navigation);
   const {colors} = useTheme();
+
+  // Focus the first VirtualizedList when component mounts
+  useEffect(() => {
+    if (firstVirtualizedListRef?.current) {
+      firstVirtualizedListRef.current.focus();
+    }
+  }, []);
 
   const example1jsx = `
   var DATA: INT[] = [];
@@ -219,7 +226,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
     return (
       <TouchableHighlight
         accessibilityLabel={item.title}
-        accessibilityRole="button"
+        accessibilityRole="listitem"
         accessible={true}
         focusable={true}
         style={styles.item}
@@ -235,7 +242,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
     return (
       <TouchableHighlight
         accessibilityLabel={item.title}
-        accessibilityRole="button"
+        accessibilityRole="listitem"
         accessible={true}
         focusable={true}
         style={item.index === selectedIndex ? styles.itemSelected : styles.item}
@@ -253,7 +260,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
     return selectedSupport === 'Multiple' ? (
       <TouchableHighlight
         accessibilityLabel={item.title}
-        accessibilityRole="button"
+        accessibilityRole="listitem"
         accessible={true}
         focusable={true}
         style={getList.includes(item.index) ? styles.itemSelected : styles.item}
@@ -273,7 +280,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
     ) : (
       <TouchableHighlight
         accessibilityLabel={item.title}
-        accessibilityRole="button"
+        accessibilityRole="listitem"
         accessible={true}
         focusable={true}
         style={
@@ -313,6 +320,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
             accessibilityLabel="VirtualizedList container"
             accessible={true}>
             <VirtualizedList
+              accessibilityRole="list"
               data={DATA}
               initialNumToRender={10}
               renderItem={renderItem}
@@ -333,6 +341,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         <ScrollView horizontal={true}>
           <View style={styles.container} accessible={true}>
             <VirtualizedList
+              accessibilityRole="list"
               data={DATA}
               initialNumToRender={10}
               renderItem={renderItem2}
@@ -355,6 +364,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         <ScrollView horizontal={true}>
           <View style={styles.container}>
             <VirtualizedList
+              accessibilityRole="list"
               data={DATA}
               initialNumToRender={10}
               renderItem={renderItem3}

--- a/NewArch/src/examples/VirtualizedListExamplePage.tsx
+++ b/NewArch/src/examples/VirtualizedListExamplePage.tsx
@@ -41,7 +41,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
     </TouchableHighlight>
   );
 
-  <VirtualizedList
+  <VirtualizedList that's like just make sure
     data={DATA}
     initialNumToRender={30}
     renderItem={renderItem}
@@ -219,6 +219,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
     return (
       <TouchableHighlight
         accessibilityLabel={item.title}
+        accessibilityRole="button"
         accessible={true}
         focusable={true}
         style={styles.item}
@@ -234,6 +235,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
     return (
       <TouchableHighlight
         accessibilityLabel={item.title}
+        accessibilityRole="button"
         accessible={true}
         focusable={true}
         style={item.index === selectedIndex ? styles.itemSelected : styles.item}
@@ -251,6 +253,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
     return selectedSupport === 'Multiple' ? (
       <TouchableHighlight
         accessibilityLabel={item.title}
+        accessibilityRole="button"
         accessible={true}
         focusable={true}
         style={getList.includes(item.index) ? styles.itemSelected : styles.item}
@@ -270,6 +273,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
     ) : (
       <TouchableHighlight
         accessibilityLabel={item.title}
+        accessibilityRole="button"
         accessible={true}
         focusable={true}
         style={
@@ -306,7 +310,8 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
           <View
             ref={firstVirtualizedListRef}
             style={styles.container}
-            accessibilityLabel="VirtualizedList container">
+            accessibilityLabel="VirtualizedList container"
+            accessible={true}>
             <VirtualizedList
               data={DATA}
               initialNumToRender={10}
@@ -316,6 +321,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
               getItem={getItem}
               accessibilityLabel={'A simple VirtualizedList'}
               focusable={true}
+              accessible={true}
             />
           </View>
         </ScrollView>
@@ -325,7 +331,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
         title="A VirtualizedList with single selection support"
         code={example2jsx}>
         <ScrollView horizontal={true}>
-          <View style={styles.container}>
+          <View style={styles.container} accessible={true}>
             <VirtualizedList
               data={DATA}
               initialNumToRender={10}
@@ -337,6 +343,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
                 'A VirtualizedList with single selection support'
               }
               focusable={true}
+              accessible={true}
             />
           </View>
         </ScrollView>

--- a/NewArch/src/examples/VirtualizedListExamplePage.tsx
+++ b/NewArch/src/examples/VirtualizedListExamplePage.tsx
@@ -298,7 +298,7 @@ export const VirtualizedListExamplePage: React.FunctionComponent<{navigation?: a
           setSelectedIndex2(item.index);
         }}
         onAccessibilityTap={() => {
-          setSelectedIndex(item.index);
+          setSelectedIndex2(item.index);
         }}>
         <Text style={styles.title}>{item.title}</Text>
       </TouchableHighlight>


### PR DESCRIPTION
## Description
Users are unable to access the list items present under 'A simple virtualized list' heading using Voice access by giving 'Show numbers' command.

### Why

Users are unable to access the list items present under 'A simple virtualized list' heading using Voice access by giving 'Show numbers' command.

Resolves [https://github.com/microsoft/react-native-gallery/issues/663]

### What

Users are unable to access the list items present under 'A simple virtualized list' heading using Voice access by giving 'Show numbers' command.

## Screenshots

Before


https://github.com/user-attachments/assets/97f3a5b5-3642-42ae-8d50-beeab191d067


After
![663-after](https://github.com/user-attachments/assets/9255cf18-82e3-44b0-87a6-d8195df1d62e)

Narrator is announcing even after changing listItem to button

https://github.com/user-attachments/assets/8a67ecd7-557a-4397-af9e-fedd4ebb28c5





 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/666)