### PR TITLE
adding changes to highlight the editable text in clipboard

### DIFF
--- a/NewArch/src/examples/ClipboardExamplePage.tsx
+++ b/NewArch/src/examples/ClipboardExamplePage.tsx
@@ -68,8 +68,8 @@ export const ClipboardExamplePage: React.FunctionComponent<{navigation?: any}> =
             value={textToCopy}
             onChangeText={setTextToCopy}
             style={{
-              backgroundColor: 'white',
-              color: 'black',
+              backgroundColor: colors.card,
+              color: colors.text,
               borderColor: colors.border,
               borderWidth: 1,
               padding: 8,

--- a/NewArch/src/examples/ClipboardExamplePage.tsx
+++ b/NewArch/src/examples/ClipboardExamplePage.tsx
@@ -5,9 +5,11 @@ import {Example} from '../components/Example';
 import {Page} from '../components/Page';
 import Clipboard from '@react-native-clipboard/clipboard';
 import {usePageFocusManagement} from '../hooks/usePageFocusManagement';
+import {useTheme} from '../Navigation';
 
 export const ClipboardExamplePage: React.FunctionComponent<{navigation?: any}> = ({navigation}) => {
   const firstClipboardButtonRef = usePageFocusManagement(navigation);
+  const {colors} = useTheme();
   const [textToCopy, setTextToCopy] = useState(
     'This text will be copied to the clipboard',
   );
@@ -65,6 +67,15 @@ export const ClipboardExamplePage: React.FunctionComponent<{navigation?: any}> =
             accessibilityLabel="Example set text to copy"
             value={textToCopy}
             onChangeText={setTextToCopy}
+            style={{
+              backgroundColor: 'white',
+              color: 'black',
+              borderColor: colors.border,
+              borderWidth: 1,
+              padding: 8,
+              minHeight: 40,
+              borderRadius: 4,
+            }}
           />
         </View>
       </Example>


### PR DESCRIPTION
## Description
This text will be copied to the clipboard' edit field is visually presented as a normal text present below the 'Copy to clipboard' button
### Why

This text will be copied to the clipboard' edit field is visually presented as a normal text present below the 'Copy to clipboard' button

Resolves [Add Relevant Issue Here]

### What

This text will be copied to the clipboard' edit field is visually presented as a normal text present below the 'Copy to clipboard' button. Also changed the font color of the text so that it can be distinguished from the background

## Screenshots
Before

https://github.com/user-attachments/assets/9bd1ddcb-be38-46cb-ac42-0d9c2919be1b


After

https://github.com/user-attachments/assets/be938f86-cc05-4fd7-9f20-a285181fee47


Add any relevant screen captures here from before or after your changes.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/667)