### PR TITLE
Fix for 669 issue.

### DIFF
--- a/NewArch/src/ComponentListPage.tsx
+++ b/NewArch/src/ComponentListPage.tsx
@@ -58,7 +58,7 @@ const ListOfComponents = ({
     <View
       accessibilityLabel={heading + 'components'}
       accessible={true}
-      accessibilityRole="none">
+      accessibilityRole="group">
       <Text accessibilityRole="header" style={styles.heading}>
         {heading}
       </Text>


### PR DESCRIPTION
## Description
Screen readers were not announcing group names "Recently added samples" and "Recently updated samples" when users navigate into or out of these button groups on the Home page.
### Why
Fixes the narrator announcement failure.

Resolves [Add Relevant Issue Here]

### What
Resolves accessibility issue where Narrator fails to announce group context when entering/exiting button groups.
Changed accessibilityRole from "none" to "group" in the ListOfComponents component to enable proper group announcements. Updated accessibility labels to provide cleaner group identification for screen readers.



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/670)