### PR TITLE
Fix for Contrast Theme in Modal in New Arch

### DIFF
--- a/NewArch/src/examples/ModalExamplePage.tsx
+++ b/NewArch/src/examples/ModalExamplePage.tsx
@@ -122,15 +122,16 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
           onPress={changeModal1}
           onAccessibilityTap={changeModal1}/>
         <Modal visible={modal1}>
-          <View style={{width: 500, height: 50}}>
-            <Text>This is a simple Modal</Text>
-            <Button
-              ref={modal1FirstButtonRef}
-              title="Close Modal"
-              accessibilityLabel="Close Modal"
-              onPress={changeModal1}
-              onAccessibilityTap={changeModal1}/>
-          </View>
+            <View style={styles.simpleModalView}>
+              <Text style={styles.simpleModalText}>This is a simple Modal</Text>
+              <Button
+                color={'#8D8383'}
+                ref={modal1FirstButtonRef}
+                title="Close Modal"
+                accessibilityLabel="Close Modal"
+                onPress={changeModal1}
+                onAccessibilityTap={changeModal1}/>
+            </View>
         </Modal>
       </Example>
       <Example
@@ -237,5 +238,22 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     textAlign: 'center',
     paddingTop: 5,
+  },
+  simpleModalView: {
+    width: 500,
+    borderRadius: 10,
+    padding: 15,
+    alignItems: 'center',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  simpleModalText: {
+    color: 'black',
+    marginBottom: 10,
   },
 });


### PR DESCRIPTION
## Description
Changes for the components visibility in constrast theme.

Resolves [#671 ]

### What

What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.
Changed button color for contrast to work.

## Screenshots
<img width="957" height="819" alt="image" src="https://github.com/user-attachments/assets/34dfc289-5ce5-40a5-9835-fe4071adda40" />

<img width="944" height="846" alt="image" src="https://github.com/user-attachments/assets/cf3c5c8a-0b18-4140-96d1-0da12637de8e" />


Add any relevant screen captures here from before or after your changes.
