### PR TITLE
'React Native Gallery Preview' text present in title bar is not adapting to Dark Mode

### DIFF
--- a/NewArch/windows/NewArch/NewArch.cpp
+++ b/NewArch/windows/NewArch/NewArch.cpp
@@ -73,6 +73,53 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR 
   appWindow.Title(L"React Native Gallery - Preview");
   appWindow.Resize({1000, 1000});
 
+  // Configure title bar to respect system theme (dark mode support)
+  try {
+    auto titleBar = appWindow.TitleBar();
+    if (titleBar) {
+      // Enable title bar theming to follow system theme
+      titleBar.ExtendsContentIntoTitleBar(false);
+      
+      // Function to apply current system theme colors
+      auto applySystemTheme = [titleBar]() {
+        try {
+          auto uiSettings = winrt::Windows::UI::ViewManagement::UISettings();
+          auto foreground = uiSettings.GetColorValue(winrt::Windows::UI::ViewManagement::UIColorType::Foreground);
+          auto background = uiSettings.GetColorValue(winrt::Windows::UI::ViewManagement::UIColorType::Background);
+          
+          // Apply system theme colors to title bar
+          titleBar.ForegroundColor(foreground);
+          titleBar.BackgroundColor(background);
+          titleBar.ButtonForegroundColor(foreground);
+          titleBar.ButtonBackgroundColor(background);
+          titleBar.ButtonHoverForegroundColor(foreground);
+          titleBar.ButtonHoverBackgroundColor(background);
+          titleBar.ButtonPressedForegroundColor(foreground);
+          titleBar.ButtonPressedBackgroundColor(background);
+          
+          // Configure inactive state colors
+          titleBar.InactiveForegroundColor(foreground);
+          titleBar.InactiveBackgroundColor(background);
+          titleBar.ButtonInactiveForegroundColor(foreground);
+          titleBar.ButtonInactiveBackgroundColor(background);
+        } catch (...) {
+          // Ignore errors when applying theme
+        }
+      };
+      
+      // Apply initial theme
+      applySystemTheme();
+      
+      // Listen for system theme changes
+      auto uiSettings = winrt::Windows::UI::ViewManagement::UISettings();
+      uiSettings.ColorValuesChanged([applySystemTheme](auto const&, auto const&) {
+        applySystemTheme();
+      });
+    }
+  } catch (...) {
+    // Silently continue if title bar theming is not supported
+  }
+
   // Update Icon
   WCHAR iconPathBuffer[MAX_PATH];
   // Copy appDirectory to iconPathBuffer

--- a/NewArch/windows/NewArch/pch.h
+++ b/NewArch/windows/NewArch/pch.h
@@ -28,6 +28,7 @@
 #include <winrt/Microsoft.UI.Dispatching.h>
 #include <winrt/Microsoft.UI.Windowing.h>
 #include <winrt/Microsoft.UI.interop.h>
+#include <winrt/Windows.UI.ViewManagement.h>
 
 // C RunTime Header Files
 #include <malloc.h>


### PR DESCRIPTION
## Description
[React Native Gallery Preview]: 'React Native Gallery Preview' text present in title bar is not adapting to 'Dark Mode'

### Why

[React Native Gallery Preview]: 'React Native Gallery Preview' text present in title bar is not adapting to 'Dark Mode'

Resolves [https://github.com/microsoft/react-native-gallery/issues/676]

### What

Added platform specific changes

## Screenshots
Before
<img width="1248" height="796" alt="676-before" src="https://github.com/user-attachments/assets/7ef28e6f-f0e2-40b7-8020-ae6e9ee7ad24" />
After
<img width="484" height="491" alt="676-after" src="https://github.com/user-attachments/assets/a5f0e8a3-4404-4c99-ae2b-f34d0832f5ff" />


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/679)