### PR TITLE
Fixing issue git 681

### DIFF
--- a/NewArch/src/components/ControlItem.tsx
+++ b/NewArch/src/components/ControlItem.tsx
@@ -99,7 +99,7 @@ const HomeComponentTile = React.forwardRef<any, HomeComponentTileProps>(
       accessibilityLabel={
         item.key === 'Button' ? 'Button1 control' : item.key + ' control'
       }
-      accessibilityHint={'click to view the ' + item.key + ' sample page'}
+      accessibilityHint={item.subtitle ? item.subtitle + '. Click to view the ' + item.key + ' sample page' : 'Click to view the ' + item.key + ' sample page'}
       style={styles.controlItem}
       onPress={() => {
         navigation.navigate(item.key);

--- a/NewArch/src/components/TileGallery.tsx
+++ b/NewArch/src/components/TileGallery.tsx
@@ -82,7 +82,8 @@ const HeaderTile = React.forwardRef<any, HeaderTileType>((props, ref) => {
       onHoverIn={() => setIsHovered(true)}
       onHoverOut={() => setIsHovered(false)}
       accessibilityRole="button"
-      accessibilityLabel={props.title}>
+      accessibilityLabel={props.title}
+      accessibilityHint={props.description}>
       <View style={styles.tileIconContent}>{props.children}</View>
       <Text style={styles.tileTitle}>{props.title}</Text>
       <Text style={styles.tileDescription}>{props.description}</Text>


### PR DESCRIPTION
## Description
The accessibilityLabel only includes the title ("Getting started", "React Native", etc.) but excludes the description ("An overview of app development options, tools, and samples", etc.).
### Why
While navigating to the 'Get started/React Native/Windows Design/GitHub...' etc links present in home page, Narrator is not announcing the subtext information. It is just announcing as "<label name>, <control type>".

### What
Added proper accessibilityHint , now narrator announces all details.

## Screenshots

https://github.com/user-attachments/assets/40c4b779-6bb7-4364-af1d-a61643e38c7c



