### PR TITLE
Narrator is not announcing the opened dialog information, once after invoking 'Open modal' button

### DIFF
--- a/NewArch/src/examples/ModalExamplePage.tsx
+++ b/NewArch/src/examples/ModalExamplePage.tsx
@@ -57,7 +57,7 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
       onShow={() => {
         setOnShowCount(onShowCount + 1);
       }}>
-      <View style={{width: 500, height: 400}}>
+      <View style={{width: 500, height: 100}}>
       <View style={styles.container}>
         <Text style={{fontWeight: 'bold'}}>Modal Events</Text>
         <Text>onShow event Count = {onShowCount}</Text>
@@ -172,7 +172,6 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
               <Text style={{fontWeight: 'bold'}}>Modal Events</Text>
               <Text>onShow event Count = {onShowCount}</Text>
               <Text>onDismiss event Count = {onDismissCount}</Text>
-              <Text style={styles.textStyle}> </Text>
             </View>
         <Modal
           visible={modal3}
@@ -182,7 +181,7 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
           onShow={() => {
             setOnShowCount(onShowCount + 1);
           }}>
-          <View style={{width: 500, height: 400}}>
+          <View style={{width: 500, height: 100}}>
             <View style={styles.container}>
               <Text style={{fontWeight: 'bold'}}>Modal Events</Text>
               <Text>onShow event Count = {onShowCount}</Text>
@@ -243,7 +242,6 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     textAlign: 'center',
     paddingTop: 5,
-    marginBottom: 20,
   },
   simpleModalView: {
     width: 500,
@@ -260,6 +258,5 @@ const styles = StyleSheet.create({
   },
   simpleModalText: {
     color: 'black',
-    marginBottom: 20,
   },
 });

--- a/NewArch/src/examples/ModalExamplePage.tsx
+++ b/NewArch/src/examples/ModalExamplePage.tsx
@@ -62,7 +62,6 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
         <Text style={{fontWeight: 'bold'}}>Modal Events</Text>
         <Text>onShow event Count = {onShowCount}</Text>
         <Text>onDismiss event Count = {onDismissCount}</Text>
-        <Text style={styles.textStyle}> </Text>
       </View>
         <Button
           title="Close Modal"

--- a/NewArch/src/examples/ModalExamplePage.tsx
+++ b/NewArch/src/examples/ModalExamplePage.tsx
@@ -11,7 +11,7 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
   const [modal2, setModal2] = React.useState(false);
   const [modal3, setModal3] = React.useState(false);
   const changeModal1 = () => {
-    AccessibilityInfo.announceForAccessibility("This is a simple simple modal")
+    AccessibilityInfo.announceForAccessibility("This is a simple modal")
     setModal1(!modal1);
   };
   const changeModal2 = () => {

--- a/NewArch/src/examples/ModalExamplePage.tsx
+++ b/NewArch/src/examples/ModalExamplePage.tsx
@@ -1,5 +1,5 @@
 'use strict';
-import {Modal, Button, View, Text, StyleSheet, Dimensions, PlatformColor} from 'react-native';
+import {Modal, Button, View, Text, StyleSheet, Dimensions, PlatformColor, AccessibilityInfo} from 'react-native';
 import React from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
@@ -11,12 +11,15 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
   const [modal2, setModal2] = React.useState(false);
   const [modal3, setModal3] = React.useState(false);
   const changeModal1 = () => {
+    AccessibilityInfo.announceForAccessibility("This is a simple simple modal")
     setModal1(!modal1);
   };
   const changeModal2 = () => {
+    AccessibilityInfo.announceForAccessibility("This is a modal with more complex styling")
     setModal2(!modal2);
   };
   const changeModal3 = () => {
+    AccessibilityInfo.announceForAccessibility("Modal Events onShow onDismiss events count close Modal")
     setModal3(!modal3);
   };
 
@@ -54,11 +57,12 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
       onShow={() => {
         setOnShowCount(onShowCount + 1);
       }}>
-      <View style={{width: 500, height: 100}}>
+      <View style={{width: 500, height: 400}}>
       <View style={styles.container}>
         <Text style={{fontWeight: 'bold'}}>Modal Events</Text>
         <Text>onShow event Count = {onShowCount}</Text>
         <Text>onDismiss event Count = {onDismissCount}</Text>
+        <Text style={styles.textStyle}> </Text>
       </View>
         <Button
           title="Close Modal"
@@ -128,7 +132,7 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
                 color={'#8D8383'}
                 ref={modal1FirstButtonRef}
                 title="Close Modal"
-                accessibilityLabel="This is a simple Modal close Modal"
+                accessibilityLabel="Close Modal"
                 onPress={changeModal1}
                 onAccessibilityTap={changeModal1}/>
             </View>
@@ -151,7 +155,7 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
               <Button
                 ref={modal2FirstButtonRef}
                 title="Close Modal"
-                accessibilityLabel="This is a Modal with more complex styling close Modal"
+                accessibilityLabel="Close Modal"
                 onPress={changeModal2}
                 onAccessibilityTap={changeModal2}/>
             </View>
@@ -168,6 +172,7 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
               <Text style={{fontWeight: 'bold'}}>Modal Events</Text>
               <Text>onShow event Count = {onShowCount}</Text>
               <Text>onDismiss event Count = {onDismissCount}</Text>
+              <Text style={styles.textStyle}> </Text>
             </View>
         <Modal
           visible={modal3}
@@ -177,7 +182,7 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
           onShow={() => {
             setOnShowCount(onShowCount + 1);
           }}>
-          <View style={{width: 500, height: 100}}>
+          <View style={{width: 500, height: 400}}>
             <View style={styles.container}>
               <Text style={{fontWeight: 'bold'}}>Modal Events</Text>
               <Text>onShow event Count = {onShowCount}</Text>
@@ -186,7 +191,7 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
             <Button
               ref={modal3FirstButtonRef}
               title="Close Modal"
-              accessibilityLabel="Modal Events onShow onDismiss events count close Modal"
+              accessibilityLabel="Close Modal"
               onPress={changeModal3}
               onAccessibilityTap={changeModal3}/>
           </View>
@@ -238,6 +243,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     textAlign: 'center',
     paddingTop: 5,
+    marginBottom: 20,
   },
   simpleModalView: {
     width: 500,
@@ -254,6 +260,6 @@ const styles = StyleSheet.create({
   },
   simpleModalText: {
     color: 'black',
-    marginBottom: 10,
+    marginBottom: 20,
   },
 });

--- a/NewArch/src/examples/ModalExamplePage.tsx
+++ b/NewArch/src/examples/ModalExamplePage.tsx
@@ -128,7 +128,7 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
                 color={'#8D8383'}
                 ref={modal1FirstButtonRef}
                 title="Close Modal"
-                accessibilityLabel="Close Modal"
+                accessibilityLabel="This is a simple Modal close Modal"
                 onPress={changeModal1}
                 onAccessibilityTap={changeModal1}/>
             </View>
@@ -151,7 +151,7 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
               <Button
                 ref={modal2FirstButtonRef}
                 title="Close Modal"
-                accessibilityLabel="Close Modal"
+                accessibilityLabel="This is a Modal with more complex styling close Modal"
                 onPress={changeModal2}
                 onAccessibilityTap={changeModal2}/>
             </View>
@@ -186,7 +186,7 @@ export const ModalExamplePage: React.FunctionComponent<{navigation?: any}> = ({n
             <Button
               ref={modal3FirstButtonRef}
               title="Close Modal"
-              accessibilityLabel="Close Modal"
+              accessibilityLabel="Modal Events onShow onDismiss events count close Modal"
               onPress={changeModal3}
               onAccessibilityTap={changeModal3}/>
           </View>


### PR DESCRIPTION
## Description

Narrator is not announcing the opened dialog information, once after invoking 'Open modal' button

### Why

Narrator is not announcing the opened dialog information, once after invoking 'Open modal' button

Resolves [https://github.com/microsoft/react-native-gallery/issues/677]

### What

Narrator is not announcing the opened dialog information, once after invoking 'Open modal' button

## Screenshots

Before

https://github.com/user-attachments/assets/2cda9524-d94a-4bf0-a8d3-7fad143d6043


After

https://github.com/user-attachments/assets/3f81175a-4780-4090-b4ff-422406cecbf0



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/689)