### PR TITLE
adding support for keyboard lef/right arrow for navigation menu items

### DIFF
--- a/NewArch/src/App.tsx
+++ b/NewArch/src/App.tsx
@@ -205,12 +205,6 @@ const DrawerCollapsibleCategory = ({
   };
 
   const handleKeyDown = (e: any) => {
-    // Handle Enter/Space to toggle expand/collapse
-    if (e.nativeEvent.key === 'Enter' || e.nativeEvent.key === ' ') {
-      e.preventDefault();
-      setIsExpanded(!isExpanded);
-      return;
-    }
     
     // Handle Left Arrow to collapse if expanded
     if (e.nativeEvent.key === 'ArrowLeft' && isExpanded) {


### PR DESCRIPTION

## Description

Tab navigation is defined for all the buttons <Home, All samples, Basic input, etc.> present in left navigation bar

### Why

Tab navigation is defined for all the buttons <Home, All samples, Basic input, etc.> present in left navigation bar. We can't use keyboard arrow to expand/ collapse the items present in the left navigation panel.

Resolves [https://github.com/microsoft/react-native-gallery/issues/705]

### What

Tab navigation is defined for all the buttons <Home, All samples, Basic input, etc.> present in left navigation bar. We can't use keyboard arrow to expand/ collapse the items present in the left navigation panel.

## Screenshots
Before

https://github.com/user-attachments/assets/b2e8e298-d26f-409e-bf22-a43381854fb8

After

https://github.com/user-attachments/assets/de6470e6-dc77-4a93-9250-8327d2569632





 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/706)