### PR TITLE
Platform color page

### DIFF
--- a/NewArch/src/RNGalleryList.ts
+++ b/NewArch/src/RNGalleryList.ts
@@ -41,6 +41,7 @@ import { ModalExamplePage } from './examples/ModalExamplePage'; // Fabric only
 import {VirtualizedListExamplePage} from './examples/VirtualizedListExamplePage';
 // import {LinearGradientExamplePage} from './examples/LinearGradientExamplePage';
 // import {NetworkExamplePage} from './examples/NetworkExamplePage';
+import {PlatformColorExamplePage} from './examples/PlatformColorExamplePage';
 // import {SvgExamplePage} from './examples/SvgExamplePage';
 // import {LottieAnimationsExamplePage} from './examples/LottieAnimationsExamplePage';
 
@@ -207,6 +208,14 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
   //   subtitle: 'Displays content on top of existing content.',
   //   type: 'Dialogs & flyouts',
   // },
+  {
+    key: 'PlatformColor',
+    component: PlatformColorExamplePage,
+    textIcon: '\uE790',
+    subtitle: 'Reference platform-specific colors that adapt to user themes and accessibility settings.',
+    type: 'System',
+    new: true,
+  },
   {
     key: 'Pressable',
     component: PressableExamplePage,

--- a/NewArch/src/examples/PlatformColorExamplePage.tsx
+++ b/NewArch/src/examples/PlatformColorExamplePage.tsx
@@ -1,0 +1,225 @@
+'use strict';
+import {View, Text, PlatformColor, ScrollView, Pressable, StyleSheet} from 'react-native';
+import React, { useState } from 'react';
+import {Example} from '../components/Example';
+import {Page} from '../components/Page';
+import {useTheme} from '@react-navigation/native';
+
+
+function PlatformColorVisualizer({ colorKey }: { colorKey: string }) {
+  const [darkText, setDarkText] = useState(false);
+  return (
+    <Pressable onPress={() => setDarkText((prev) => !prev)}>
+      <Text
+        style={[
+          styles.colorText,
+          { backgroundColor: PlatformColor(colorKey), color: darkText ? '#000' : '#fff' },
+        ]}
+      >
+        {colorKey}
+      </Text>
+    </Pressable>
+  );
+}
+
+// Source for these is here: https://github.com/microsoft/react-native-windows/blob/63e9eaaa2249c3f7b46200203cb69c006c5770a9/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.cpp
+// Grouping done in alignment with WinUI Gallery's Design->Color section
+const platformColorGroups: { header: string; colors: string[] }[] = [
+  {
+    header: 'Control Fill',
+    colors: [
+      'ControlFillColorDefault',
+      'ControlFillColorSecondary',
+      'ControlFillColorTertiary',
+      'ControlFillColorDisabled',
+      'ControlFillColorTransparent',
+    ],
+  },
+  {
+    header: 'Control Alt Fill',
+    colors: [
+      'ControlAltFillColorSecondary',
+      'ControlAltFillColorTertiary',
+      'ControlAltFillColorQuarternary',
+      'ControlAltFillColorDisabled',
+    ],
+  },
+  {
+    header: 'Strong Fill',
+    colors: [
+      'ControlStrongFillColorDefault',
+      'ControlStrongFillColorDisabled',
+    ],
+  },
+  {
+    header: 'Subtle Fill',
+    colors: [
+      'SubtleFillColorTransparent',
+      'SubtleFillColorSecondary',
+    ],
+  },
+  {
+    header: 'Accent Fill',
+    colors: [
+      'AccentFillColorDefault',
+      'AccentFillColorSecondary',
+      'AccentFillColorTertiary',
+      'AccentFillColorDisabled',
+    ],
+  },
+  {
+    header: 'Text',
+    colors: [
+      'TextFillColorPrimary',
+      'TextFillColorSecondary',
+      'TextFillColorDisabled',
+    ],
+  },
+  {
+    header: 'Text On Accent',
+    colors: [
+      'TextOnAccentFillColorPrimary',
+      'TextOnAccentFillColorDisabled',
+    ],
+  },
+  {
+    header: 'Control Stroke',
+    colors: [
+      'ControlStrokeColorDefault',
+      'ControlStrokeColorSecondary',
+      'ControlStrokeColorOnAccentSecondary',
+      'ControlStrongStrokeColorDefault',
+      'ControlStrongStrokeColorDisabled',
+    ],
+  },
+  {
+    header: 'Other',
+    colors: [
+      'SolidBackgroundFillColorBase',
+      'CircleElevationBorder',
+      'ProgressRingForegroundTheme',
+      'TextControlForeground',
+      'ScrollBarButtonBackground',
+      'ScrollBarButtonBackgroundPointerOver',
+      'ScrollBarButtonBackgroundPressed',
+      'ScrollBarButtonBackgroundDisabled',
+      'ScrollBarButtonArrowForeground',
+      'ScrollBarButtonArrowForegroundPointerOver',
+      'ScrollBarButtonArrowForegroundPressed',
+      'ScrollBarButtonArrowForegroundDisabled',
+      'ScrollBarThumbFill',
+      'ScrollBarThumbFillPointerOver',
+      'ScrollBarThumbFillPressed',
+      'ScrollBarThumbFillDisabled',
+      'ScrollBarTrackFill',
+      'ToolTipBackground',
+      'ToolTipForeground',
+      'ToolTipBorderBrush',
+      'SystemChromeMediumLowColor',
+      'SystemControlForegroundBaseHighColor',
+      'SystemControlTransientBorderColor',
+      'FocusVisualPrimary',
+      'FocusVisualSecondary',
+    ],
+  },
+];
+
+
+function PlatformColorList() {
+  const scrollChildren = [];
+  const stickyHeaderIndices = [];
+  let childIndex = 0;
+  for (const group of platformColorGroups) {
+    stickyHeaderIndices.push(childIndex);
+    scrollChildren.push(
+      <Text key={group.header} style={styles.sectionHeader}>{group.header}</Text>
+    );
+    childIndex++;
+    for (const colorKey of group.colors) {
+      scrollChildren.push(
+        <PlatformColorVisualizer key={colorKey} colorKey={colorKey} />
+      );
+      childIndex++;
+    }
+  }
+
+  return (
+    <ScrollView contentContainerStyle={styles.scrollContent}>
+    {scrollChildren}
+    </ScrollView>
+  );
+}
+
+export const PlatformColorExamplePage: React.FunctionComponent<{}> = () => {
+  const example1jsx = `<View
+  style={{
+    backgroundColor: PlatformColor('SystemAccentColor'),
+    padding: 20,
+    borderRadius: 8,
+  }}>
+  <Text style={{
+    color: PlatformColor('TextOnAccentFillColorPrimary'),
+    textAlign: 'center'
+    }}>
+    System Accent Color
+  </Text>
+</View>`;
+
+  return (
+    <Page
+      title="PlatformColor"
+      description="PlatformColor lets you reference the platform's color system. On Windows, you can reference system colors that automatically adapt to the user's theme and accessibility settings."
+      componentType="Core"
+      pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/PlatformColorExamplePage.tsx"
+      documentation={[
+        {
+          label: 'PlatformColor',
+          url: 'https://reactnative.dev/docs/platformcolor',
+        },
+        {
+          label: 'Windows System Colors',
+          url: 'https://docs.microsoft.com/en-us/windows/apps/design/style/color',
+        },
+      ]}>
+      <Example title="PlatformColor example" code={example1jsx}>
+        <View
+          style={{
+            backgroundColor: PlatformColor('SystemAccentColor'),
+            padding: 20,
+            borderRadius: 8,
+          }}>
+          <Text style={{color: PlatformColor('TextOnAccentFillColorPrimary'), textAlign: 'center'}}>
+            System Accent Color
+          </Text>
+        </View>
+      </Example>
+
+      <Example title="Available color values" code="// Use PlatformColor with any of the values above">
+        <PlatformColorList />
+      </Example>
+    </Page>
+  );
+};
+
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    gap: 8,
+    alignItems: 'flex-start',
+  },
+  sectionHeader: {
+    fontWeight: '600',
+    fontSize: 16,
+    marginTop: 16,
+    marginBottom: 4,
+  },
+  colorText: {
+    paddingTop: 6,
+    paddingBottom: 4,
+    paddingHorizontal: 14,
+    borderRadius: 6,
+    color: '#fff',
+    fontSize: 15,
+    overflow: 'hidden',
+  },
+});

--- a/NewArch/src/examples/PlatformColorExamplePage.tsx
+++ b/NewArch/src/examples/PlatformColorExamplePage.tsx
@@ -1,143 +1,241 @@
 'use strict';
-import {View, Text, PlatformColor, ScrollView, Pressable, StyleSheet} from 'react-native';
-import React, { useState } from 'react';
+import {View, Text, PlatformColor, ScrollView, StyleSheet, Switch, Button} from 'react-native';
+import React, { useState, createContext, useContext } from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
-import {useTheme} from '@react-navigation/native';
+
+type ThemeContextType = {
+  isDarkMode: boolean;
+};
+
+const ThemeContext = createContext<ThemeContextType>({ isDarkMode: false });
 
 
-function PlatformColorVisualizer({ colorKey }: { colorKey: string }) {
-  const [darkText, setDarkText] = useState(false);
+type ColorGroup = 'background' | 'border' | 'text';
+type PlatformColorType = { key: string; group?: ColorGroup };
+function PlatformColorVisualizer({ color }: { color: PlatformColorType }) {
+  const { isDarkMode } = useContext(ThemeContext);
+  let backgroundStyle;
+  let textStyle;
+  if (color.group === 'border') {
+    backgroundStyle = { borderWidth: 2, borderColor: PlatformColor(color.key), backgroundColor: 'transparent' };
+  } else if (color.group === 'text') {
+    backgroundStyle = { backgroundColor: PlatformColor(color.key) };
+    textStyle = { color: 'transparent' };
+  } else {
+    backgroundStyle = { backgroundColor: PlatformColor(color.key) };
+  }
   return (
-    <Pressable onPress={() => setDarkText((prev) => !prev)}>
-      <Text
-        style={[
-          styles.colorText,
-          { backgroundColor: PlatformColor(colorKey), color: darkText ? '#000' : '#fff' },
-        ]}
+    <View
+      style={{ flexDirection: 'row', alignItems: 'center' }}>
+      <View
+        style={{
+          height: 32,
+          width: 32,
+          marginRight: 8,
+          borderRadius: 4,
+          justifyContent: 'center',
+          alignItems: 'center',
+          ...backgroundStyle,
+        }}
       >
-        {colorKey}
+        <Text style={textStyle} accessible={false}>O</Text>
+      </View>
+      <Text
+        style={[styles.colorVisualizerText, { color: isDarkMode ? '#FFF' : '#000' }]}
+      >
+        {color.key}
       </Text>
-    </Pressable>
+    </View>
   );
 }
 
 // Source for these is here: https://github.com/microsoft/react-native-windows/blob/63e9eaaa2249c3f7b46200203cb69c006c5770a9/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.cpp
 // Grouping done in alignment with WinUI Gallery's Design->Color section
-const platformColorGroups: { header: string; colors: string[] }[] = [
-  {
-    header: 'Control Fill',
-    colors: [
-      'ControlFillColorDefault',
-      'ControlFillColorSecondary',
-      'ControlFillColorTertiary',
-      'ControlFillColorDisabled',
-      'ControlFillColorTransparent',
-    ],
-  },
-  {
-    header: 'Control Alt Fill',
-    colors: [
-      'ControlAltFillColorSecondary',
-      'ControlAltFillColorTertiary',
-      'ControlAltFillColorQuarternary',
-      'ControlAltFillColorDisabled',
-    ],
-  },
-  {
-    header: 'Strong Fill',
-    colors: [
-      'ControlStrongFillColorDefault',
-      'ControlStrongFillColorDisabled',
-    ],
-  },
-  {
-    header: 'Subtle Fill',
-    colors: [
-      'SubtleFillColorTransparent',
-      'SubtleFillColorSecondary',
-    ],
-  },
-  {
-    header: 'Accent Fill',
-    colors: [
-      'AccentFillColorDefault',
-      'AccentFillColorSecondary',
-      'AccentFillColorTertiary',
-      'AccentFillColorDisabled',
-    ],
-  },
-  {
-    header: 'Text',
-    colors: [
-      'TextFillColorPrimary',
-      'TextFillColorSecondary',
-      'TextFillColorDisabled',
-    ],
-  },
-  {
-    header: 'Text On Accent',
-    colors: [
-      'TextOnAccentFillColorPrimary',
-      'TextOnAccentFillColorDisabled',
-    ],
-  },
-  {
-    header: 'Control Stroke',
-    colors: [
-      'ControlStrokeColorDefault',
-      'ControlStrokeColorSecondary',
-      'ControlStrokeColorOnAccentSecondary',
-      'ControlStrongStrokeColorDefault',
-      'ControlStrongStrokeColorDisabled',
-    ],
-  },
-  {
-    header: 'Other',
-    colors: [
-      'SolidBackgroundFillColorBase',
-      'CircleElevationBorder',
-      'ProgressRingForegroundTheme',
-      'TextControlForeground',
-      'ScrollBarButtonBackground',
-      'ScrollBarButtonBackgroundPointerOver',
-      'ScrollBarButtonBackgroundPressed',
-      'ScrollBarButtonBackgroundDisabled',
-      'ScrollBarButtonArrowForeground',
-      'ScrollBarButtonArrowForegroundPointerOver',
-      'ScrollBarButtonArrowForegroundPressed',
-      'ScrollBarButtonArrowForegroundDisabled',
-      'ScrollBarThumbFill',
-      'ScrollBarThumbFillPointerOver',
-      'ScrollBarThumbFillPressed',
-      'ScrollBarThumbFillDisabled',
-      'ScrollBarTrackFill',
-      'ToolTipBackground',
-      'ToolTipForeground',
-      'ToolTipBorderBrush',
-      'SystemChromeMediumLowColor',
-      'SystemControlForegroundBaseHighColor',
-      'SystemControlTransientBorderColor',
-      'FocusVisualPrimary',
-      'FocusVisualSecondary',
-    ],
-  },
+const platformColorGroups: { header: string; group?: string; colors: PlatformColorType[] }[] = [
+        {
+          header: 'Control Fill',
+          colors: [
+            { key: 'ControlFillColorDefault' },
+            { key: 'ControlFillColorSecondary' },
+            { key: 'ControlFillColorTertiary' },
+            { key: 'ControlFillColorDisabled' },
+            { key: 'ControlFillColorTransparent' },
+          ],
+        },
+        {
+          header: 'Strong Fill',
+          colors: [
+            { key: 'ControlStrongFillColorDefault' },
+            { key: 'ControlStrongFillColorDisabled' },
+          ],
+        },
+        {
+          header: 'Control Alt Fill',
+          colors: [
+            { key: 'ControlAltFillColorSecondary' },
+            { key: 'ControlAltFillColorTertiary' },
+            { key: 'ControlAltFillColorQuarternary' },
+            { key: 'ControlAltFillColorDisabled' },
+          ],
+        },
+        {
+          header: 'Subtle Fill',
+          colors: [
+            { key: 'SubtleFillColorTransparent' },
+            { key: 'SubtleFillColorSecondary' },
+          ],
+        },
+        {
+          header: 'Accent Fill',
+          colors: [
+            { key: 'AccentFillColorDefault' },
+            { key: 'AccentFillColorSecondary' },
+            { key: 'AccentFillColorTertiary' },
+            { key: 'AccentFillColorDisabled' },
+          ],
+        },
+        {
+          header: 'Accent',
+          group: 'system',
+          colors: [
+            { key: 'Accent' },
+            { key: 'AccentDark1' },
+            { key: 'AccentDark2' },
+            { key: 'AccentDark3' },
+            { key: 'AccentLight1' },
+            { key: 'AccentLight2' },
+            { key: 'AccentLight3' },
+            //{ key: 'Complement' },
+            { key: 'Foreground' },
+          ],
+        },
+        {
+          header: 'Text',
+          colors: [
+            { key: 'TextFillColorPrimary', group: 'text' },
+            { key: 'TextFillColorSecondary', group: 'text' },
+            { key: 'TextFillColorDisabled', group: 'text' },
+          ],
+        },
+        {
+          header: 'Text On Accent',
+          colors: [
+            { key: 'TextOnAccentFillColorPrimary', group: 'text' },
+            { key: 'TextOnAccentFillColorDisabled', group: 'text' },
+          ],
+        },
+        {
+          header: 'Control Stroke',
+          colors: [
+            { key: 'ControlStrokeColorDefault', group: 'border' },
+            { key: 'ControlStrokeColorSecondary', group: 'border' },
+            { key: 'ControlStrokeColorOnAccentSecondary', group: 'border' },
+            { key: 'ControlStrongStrokeColorDefault', group: 'border' },
+            { key: 'ControlStrongStrokeColorDisabled', group: 'border' },
+          ],
+        },
+        {
+          header: 'Other',
+          colors: [
+            { key: 'SolidBackgroundFillColorBase' },
+            { key: 'CircleElevationBorder', group: 'border' },
+            { key: 'ProgressRingForegroundTheme' },
+            { key: 'TextControlForeground' },
+            { key: 'ScrollBarButtonBackground' },
+            { key: 'ScrollBarButtonBackgroundPointerOver' },
+            { key: 'ScrollBarButtonBackgroundPressed' },
+            { key: 'ScrollBarButtonBackgroundDisabled' },
+            { key: 'ScrollBarButtonArrowForeground' },
+            { key: 'ScrollBarButtonArrowForegroundPointerOver' },
+            { key: 'ScrollBarButtonArrowForegroundPressed' },
+            { key: 'ScrollBarButtonArrowForegroundDisabled' },
+            { key: 'ScrollBarThumbFill' },
+            { key: 'ScrollBarThumbFillPointerOver' },
+            { key: 'ScrollBarThumbFillPressed' },
+            { key: 'ScrollBarThumbFillDisabled' },
+            { key: 'ScrollBarTrackFill' },
+            { key: 'ToolTipBackground' },
+            { key: 'ToolTipForeground' },
+            { key: 'ToolTipBorderBrush', group: 'border' },
+            { key: 'SystemChromeMediumLowColor' },
+            { key: 'SystemControlForegroundBaseHighColor' },
+            { key: 'SystemControlTransientBorderColor', group: 'border' },
+            { key: 'FocusVisualPrimary', group: 'border' },
+            { key: 'FocusVisualSecondary', group: 'border' },
+          ],
+        },
+        {
+          header: 'System',
+          group: 'system',
+          colors: [
+            { key: 'AccentColor' },
+            { key: 'ActiveCaption' },
+            { key: 'Background' },
+            { key: 'ButtonFace' },
+            { key: 'ButtonText' },
+            { key: 'CaptionText' },
+            { key: 'GrayText' },
+            { key: 'Highlight' },
+            { key: 'HighlightText' },
+            { key: 'Hotlight' },
+            { key: 'InactiveCaption' },
+            { key: 'InactiveCaptionText' },
+            { key: 'NonTextHigh' },
+            { key: 'NonTextLow' },
+            { key: 'NonTextMedium' },
+            { key: 'NonTextMediumHigh' },
+            { key: 'NonTextMediumLow' },
+            { key: 'OverlayOutsidePopup' },
+            { key: 'PageBackground' },
+            { key: 'PopupBackground' },
+            { key: 'TextContrastWithHigh' },
+            { key: 'TextHigh' },
+            { key: 'TextLow' },
+            { key: 'TextMedium' },
+            { key: 'Window' },
+            { key: 'WindowText' },
+        ],
+    },
 ];
 
 
-function PlatformColorList() {
+const groupLabels: { group: ColorGroup | 'fill' | 'system'; label: string }[] = [
+  { group: 'background', label: 'Fill' },
+  { group: 'border', label: 'Stroke' },
+  { group: 'text', label: 'Text' },
+  { group: 'system', label: 'System' },
+];
+
+function PlatformColorList({ groupFilter }: { groupFilter: ColorGroup | 'fill' | 'system' }) {
+  const { isDarkMode } = useContext(ThemeContext);
   const scrollChildren = [];
   const stickyHeaderIndices = [];
   let childIndex = 0;
   for (const group of platformColorGroups) {
+    // Filter colors by group
+    const filteredColors = group.colors.filter(color => {
+      if (groupFilter === 'system') {
+        return group.header === 'System' || group.header === 'Accent';
+      }
+      if (groupFilter === 'background') {
+        // Exclude System and Accent groups from background filter
+        if (group.header === 'System' || group.header === 'Accent') {
+          return false;
+        }
+        return !color.group || color.group === 'background';
+      }
+      return color.group === groupFilter;
+    });
+    if (filteredColors.length === 0) continue;
     stickyHeaderIndices.push(childIndex);
     scrollChildren.push(
-      <Text key={group.header} style={styles.sectionHeader}>{group.header}</Text>
+      <Text key={group.header} style={[styles.sectionHeader, { color: isDarkMode ? '#FFF' : '#000' }]}>{group.header}</Text>
     );
     childIndex++;
-    for (const colorKey of group.colors) {
+    for (const color of filteredColors) {
       scrollChildren.push(
-        <PlatformColorVisualizer key={colorKey} colorKey={colorKey} />
+        <PlatformColorVisualizer key={`${group.header}_${color.key}`} color={color} />
       );
       childIndex++;
     }
@@ -145,25 +243,52 @@ function PlatformColorList() {
 
   return (
     <ScrollView contentContainerStyle={styles.scrollContent}>
-    {scrollChildren}
+      {scrollChildren}
     </ScrollView>
   );
 }
 
+function PlatformColorValueList() {
+  const [isDarkMode, setIsDarkMode] = useState(false);
+  const [groupFilter, setGroupFilter] = useState<ColorGroup | 'fill' | 'system'>('background');
+
+  return (
+    <View style={{flex: 1, padding: 12}}>
+      <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 16 }}>
+        <Text style={{ marginRight: 8 }}>Dark Background</Text>
+        <Switch value={isDarkMode} onValueChange={setIsDarkMode} />
+      </View>
+      <View style={{ flexDirection: 'row', marginBottom: 16 }}>
+        {groupLabels.map(({ group, label }) => (
+          <View key={group} style={{ marginRight: 8 }}>
+            <Button
+              title={label}
+              onPress={() => setGroupFilter(group)}
+              color={groupFilter === group ? PlatformColor('Accent') : PlatformColor('ControlFillColorDefault')}
+            />
+          </View>
+        ))}
+      </View>
+      <ThemeContext.Provider value={{ isDarkMode }}>
+        <View style={{ flexShrink: 1, flexGrow: 1, padding: 24, borderRadius: 12, backgroundColor: isDarkMode ? '#444' : '#EFEFEF' }}>
+          <PlatformColorList groupFilter={groupFilter}/>
+        </View>
+      </ThemeContext.Provider>
+    </View>
+  );
+}
+
 export const PlatformColorExamplePage: React.FunctionComponent<{}> = () => {
-  const example1jsx = `<View
+  const example1jsx = `<Text
   style={{
-    backgroundColor: PlatformColor('SystemAccentColor'),
+    backgroundColor: PlatformColor('AccentFillColorDefault'), 
     padding: 20,
     borderRadius: 8,
-  }}>
-  <Text style={{
     color: PlatformColor('TextOnAccentFillColorPrimary'),
     textAlign: 'center'
-    }}>
-    System Accent Color
-  </Text>
-</View>`;
+  }}>
+  System Accent Color
+</Text>`;
 
   return (
     <Page
@@ -182,25 +307,23 @@ export const PlatformColorExamplePage: React.FunctionComponent<{}> = () => {
         },
       ]}>
       <Example title="PlatformColor example" code={example1jsx}>
-        <View
-          style={{
-            backgroundColor: PlatformColor('SystemAccentColor'),
+          <Text style={{
+            backgroundColor: PlatformColor('AccentFillColorDefault'), 
             padding: 20,
             borderRadius: 8,
+            color: PlatformColor('TextOnAccentFillColorPrimary'),
+            textAlign: 'center'
           }}>
-          <Text style={{color: PlatformColor('TextOnAccentFillColorPrimary'), textAlign: 'center'}}>
             System Accent Color
           </Text>
-        </View>
       </Example>
 
       <Example title="Available color values" code="// Use PlatformColor with any of the values above">
-        <PlatformColorList />
+        <PlatformColorValueList />
       </Example>
     </Page>
   );
 };
-
 
 const styles = StyleSheet.create({
   scrollContent: {
@@ -213,13 +336,11 @@ const styles = StyleSheet.create({
     marginTop: 16,
     marginBottom: 4,
   },
-  colorText: {
+  colorVisualizerText: {
     paddingTop: 6,
     paddingBottom: 4,
     paddingHorizontal: 14,
     borderRadius: 6,
-    color: '#fff',
     fontSize: 15,
-    overflow: 'hidden',
   },
 });

--- a/src/RNGalleryList.ts
+++ b/src/RNGalleryList.ts
@@ -40,6 +40,7 @@ import {ExpanderExamplePage} from './examples/ExpanderExamplePage';
 import {VirtualizedListExamplePage} from './examples/VirtualizedListExamplePage';
 import {LinearGradientExamplePage} from './examples/LinearGradientExamplePage';
 import {NetworkExamplePage} from './examples/NetworkExamplePage';
+import {PlatformColorExamplePage} from './examples/PlatformColorExamplePage';
 import {SvgExamplePage} from './examples/SvgExamplePage';
 import {LottieAnimationsExamplePage} from './examples/LottieAnimationsExamplePage';
 
@@ -196,6 +197,14 @@ export const RNGalleryList: Array<IRNGalleryExample> = [
     imageIcon: require('../assets/ControlImages/ComboBox.png'),
     subtitle: 'A drop-down list of items a user can select from.',
     type: 'Basic Input',
+  },
+  {
+    key: 'PlatformColor',
+    component: PlatformColorExamplePage,
+    textIcon: '\uE790',
+    subtitle: 'Reference platform-specific colors that adapt to user themes and accessibility settings.',
+    type: 'System',
+    new: true,
   },
   {
     key: 'Popup',

--- a/src/examples/PlatformColorExamplePage.tsx
+++ b/src/examples/PlatformColorExamplePage.tsx
@@ -1,136 +1,162 @@
 'use strict';
-import {View, Text, PlatformColor, ScrollView, Pressable, StyleSheet} from 'react-native';
-import React, { useState } from 'react';
+import {View, Text, PlatformColor, ScrollView, StyleSheet, Switch, Button} from 'react-native';
+import React, { useState, createContext, useContext } from 'react';
 import {Example} from '../components/Example';
 import {Page} from '../components/Page';
 
+type ThemeContextType = {
+  isDarkMode: boolean;
+};
 
-function PlatformColorVisualizer({ colorKey }: { colorKey: string }) {
-  const [darkText, setDarkText] = useState(false);
+const ThemeContext = createContext<ThemeContextType>({ isDarkMode: false });
+
+
+type ColorGroup = 'background' | 'border' | 'text';
+type PlatformColorType = { key: string; group?: ColorGroup };
+function PlatformColorVisualizer({ color }: { color: PlatformColorType }) {
+  const { isDarkMode } = useContext(ThemeContext);
+  let backgroundStyle;
+  let textStyle;
+  if (color.group === 'border') {
+    backgroundStyle = { borderWidth: 2, borderColor: PlatformColor(color.key), backgroundColor: 'transparent' };
+  } else if (color.group === 'text') {
+    backgroundStyle = { backgroundColor: PlatformColor(color.key) };
+    textStyle = { color: 'transparent' };
+  } else {
+    backgroundStyle = { backgroundColor: PlatformColor(color.key) };
+  }
   return (
-    <Pressable
-        style={{backgroundColor: PlatformColor(colorKey)}}
-        onPress={() => setDarkText((prev) => !prev)}>
-      <Text
-        style={[
-          styles.colorText,
-          { color: darkText ? '#000' : '#fff' },
-        ]}
+    <View
+      style={{ flexDirection: 'row', alignItems: 'center' }}>
+      <View
+        style={{
+          height: 32,
+          width: 32,
+          marginRight: 8,
+          borderRadius: 4,
+          justifyContent: 'center',
+          alignItems: 'center',
+          ...backgroundStyle,
+        }}
       >
-        {colorKey}
+        <Text style={textStyle} accessible={false}>O</Text>
+      </View>
+      <Text
+        style={[styles.colorVisualizerText, { color: isDarkMode ? '#FFF' : '#000' }]}
+      >
+        {color.key}
       </Text>
-    </Pressable>
+    </View>
   );
 }
 
-// Source for these is here: https://github.com/microsoft/react-native-windows/blob/63e9eaaa2249c3f7b46200203cb69c006c5770a9/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.cpp
 // Grouping done in alignment with WinUI Gallery's Design->Color section
-const platformColorGroups: { header: string; colors: string[] }[] = [
+const platformColorGroups: { header: string; group?: string; colors: PlatformColorType[] }[] = [
   {
     header: 'Control Fill',
     colors: [
-      'ControlFillColorDefault',
-      'ControlFillColorSecondary',
-      'ControlFillColorTertiary',
-      'ControlFillColorDisabled',
-      'ControlFillColorTransparent',
-    ],
-  },
-  {
-    header: 'Control Alt Fill',
-    colors: [
-      'ControlAltFillColorSecondary',
-      'ControlAltFillColorTertiary',
-      'ControlAltFillColorQuarternary',
-      'ControlAltFillColorDisabled',
+      { key: 'ControlFillColorDefault' },
+      { key: 'ControlFillColorSecondary' },
+      { key: 'ControlFillColorTertiary' },
+      { key: 'ControlFillColorDisabled' },
+      { key: 'ControlFillColorTransparent' },
     ],
   },
   {
     header: 'Strong Fill',
     colors: [
-      'ControlStrongFillColorDefault',
-      'ControlStrongFillColorDisabled',
+      { key: 'ControlStrongFillColorDefault' },
+      { key: 'ControlStrongFillColorDisabled' },
+    ],
+  },
+  {
+    header: 'Control Alt Fill',
+    colors: [
+      { key: 'ControlAltFillColorSecondary' },
+      { key: 'ControlAltFillColorTertiary' },
+      { key: 'ControlAltFillColorQuarternary' },
+      { key: 'ControlAltFillColorDisabled' },
     ],
   },
   {
     header: 'Subtle Fill',
     colors: [
-      'SubtleFillColorTransparent',
-      'SubtleFillColorSecondary',
+      { key: 'SubtleFillColorTransparent' },
+      { key: 'SubtleFillColorSecondary' },
     ],
   },
   {
     header: 'Accent Fill',
     colors: [
-      'SystemAccentColor',
-      'AccentFillColorDisabled',
+      { key: 'AccentFillColorDefault' },
+      { key: 'AccentFillColorSecondary' },
+      { key: 'AccentFillColorTertiary' },
+      { key: 'AccentFillColorDisabled' },
     ],
   },
   {
     header: 'Text',
     colors: [
-      'TextFillColorPrimary',
-      'TextFillColorSecondary',
-      'TextFillColorDisabled',
+      { key: 'TextFillColorPrimary', group: 'text' },
+      { key: 'TextFillColorSecondary', group: 'text' },
+      { key: 'TextFillColorDisabled', group: 'text' },
     ],
   },
   {
     header: 'Text On Accent',
     colors: [
-      'TextOnAccentFillColorPrimary',
-      'TextOnAccentFillColorDisabled',
+      { key: 'TextOnAccentFillColorPrimary', group: 'text' },
+      { key: 'TextOnAccentFillColorDisabled', group: 'text' },
     ],
   },
   {
     header: 'Control Stroke',
     colors: [
-      'ControlStrokeColorDefault',
-      'ControlStrokeColorSecondary',
-      'ControlStrokeColorOnAccentSecondary',
-      'ControlStrongStrokeColorDefault',
-      'ControlStrongStrokeColorDisabled',
-    ],
-  },
-  {
-    header: 'Other',
-    colors: [
-      'SolidBackgroundFillColorBase',
-      'TextControlForeground',
-      'ScrollBarButtonBackground',
-      'ScrollBarButtonBackgroundPointerOver',
-      'ScrollBarButtonBackgroundPressed',
-      'ScrollBarButtonBackgroundDisabled',
-      'ScrollBarButtonArrowForeground',
-      'ScrollBarButtonArrowForegroundPointerOver',
-      'ScrollBarButtonArrowForegroundPressed',
-      'ScrollBarButtonArrowForegroundDisabled',
-      'ScrollBarThumbFill',
-      'ScrollBarThumbFillPointerOver',
-      'ScrollBarThumbFillPressed',
-      'ScrollBarThumbFillDisabled',
-      'ScrollBarTrackFill',
-      'ToolTipBackground',
-      'ToolTipForeground',
-      'ToolTipBorderBrush',
-      'SystemChromeMediumLowColor'
+      { key: 'ControlStrokeColorDefault', group: 'border' },
+      { key: 'ControlStrokeColorSecondary', group: 'border' },
+      { key: 'ControlStrokeColorOnAccentSecondary', group: 'border' },
+      { key: 'ControlStrongStrokeColorDefault', group: 'border' },
+      { key: 'ControlStrongStrokeColorDisabled', group: 'border' },
     ],
   },
 ];
 
 
-function PlatformColorList() {
+const groupLabels: { group: ColorGroup | 'fill' | 'system'; label: string }[] = [
+  { group: 'background', label: 'Fill' },
+  { group: 'border', label: 'Stroke' },
+  { group: 'text', label: 'Text' },
+];
+
+function PlatformColorList({ groupFilter }: { groupFilter: ColorGroup | 'fill' | 'system' }) {
+  const { isDarkMode } = useContext(ThemeContext);
   const scrollChildren = [];
   const stickyHeaderIndices = [];
   let childIndex = 0;
   for (const group of platformColorGroups) {
+    // Filter colors by group
+    const filteredColors = group.colors.filter(color => {
+      if (groupFilter === 'system') {
+        return group.header === 'System' || group.header === 'Accent';
+      }
+      if (groupFilter === 'background') {
+        // Exclude System and Accent groups from background filter
+        if (group.header === 'System' || group.header === 'Accent') {
+          return false;
+        }
+        return !color.group || color.group === 'background';
+      }
+      return color.group === groupFilter;
+    });
+    if (filteredColors.length === 0) continue;
     stickyHeaderIndices.push(childIndex);
     scrollChildren.push(
-      <Text key={group.header} style={styles.sectionHeader}>{group.header}</Text>
+      <Text key={group.header} style={[styles.sectionHeader, { color: isDarkMode ? '#FFF' : '#000' }]}>{group.header}</Text>
     );
     childIndex++;
-    for (const colorKey of group.colors) {
+    for (const color of filteredColors) {
       scrollChildren.push(
-        <PlatformColorVisualizer key={colorKey} colorKey={colorKey} />
+        <PlatformColorVisualizer key={`${group.header}_${color.key}`} color={color} />
       );
       childIndex++;
     }
@@ -140,6 +166,36 @@ function PlatformColorList() {
     <ScrollView contentContainerStyle={styles.scrollContent}>
       {scrollChildren}
     </ScrollView>
+  );
+}
+
+function PlatformColorValueList() {
+  const [isDarkMode, setIsDarkMode] = useState(false);
+  const [groupFilter, setGroupFilter] = useState<ColorGroup | 'fill' | 'system'>('background');
+
+  return (
+    <View style={{flex: 1, padding: 12}}>
+      <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 16 }}>
+        <Text style={{ marginRight: 8 }}>Dark Background</Text>
+        <Switch value={isDarkMode} onValueChange={setIsDarkMode} />
+      </View>
+      <View style={{ flexDirection: 'row', marginBottom: 16 }}>
+        {groupLabels.map(({ group, label }) => (
+          <View key={group} style={{ marginRight: 8 }}>
+            <Button
+              title={label}
+              onPress={() => setGroupFilter(group)}
+              color={groupFilter === group ? PlatformColor('ControlStrongFillColorDisabled') : PlatformColor('ControlFillColorDefault')}
+            />
+          </View>
+        ))}
+      </View>
+      <ThemeContext.Provider value={{ isDarkMode }}>
+        <View style={{ flexShrink: 1, flexGrow: 1, padding: 24, borderRadius: 12, backgroundColor: isDarkMode ? '#444' : '#EFEFEF' }}>
+          <PlatformColorList groupFilter={groupFilter}/>
+        </View>
+      </ThemeContext.Provider>
+    </View>
   );
 }
 
@@ -188,7 +244,7 @@ export const PlatformColorExamplePage: React.FunctionComponent<{}> = () => {
       </Example>
 
       <Example title="Available color values" code="// Use PlatformColor with any of the values above">
-        <PlatformColorList />
+        <PlatformColorValueList />
       </Example>
     </Page>
   );
@@ -206,13 +262,11 @@ const styles = StyleSheet.create({
     marginTop: 16,
     marginBottom: 4,
   },
-  colorText: {
+  colorVisualizerText: {
     paddingTop: 6,
     paddingBottom: 4,
     paddingHorizontal: 14,
     borderRadius: 6,
-    color: '#fff',
     fontSize: 15,
-    overflow: 'hidden',
   },
 });

--- a/src/examples/PlatformColorExamplePage.tsx
+++ b/src/examples/PlatformColorExamplePage.tsx
@@ -1,0 +1,218 @@
+'use strict';
+import {View, Text, PlatformColor, ScrollView, Pressable, StyleSheet} from 'react-native';
+import React, { useState } from 'react';
+import {Example} from '../components/Example';
+import {Page} from '../components/Page';
+
+
+function PlatformColorVisualizer({ colorKey }: { colorKey: string }) {
+  const [darkText, setDarkText] = useState(false);
+  return (
+    <Pressable
+        style={{backgroundColor: PlatformColor(colorKey)}}
+        onPress={() => setDarkText((prev) => !prev)}>
+      <Text
+        style={[
+          styles.colorText,
+          { color: darkText ? '#000' : '#fff' },
+        ]}
+      >
+        {colorKey}
+      </Text>
+    </Pressable>
+  );
+}
+
+// Source for these is here: https://github.com/microsoft/react-native-windows/blob/63e9eaaa2249c3f7b46200203cb69c006c5770a9/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.cpp
+// Grouping done in alignment with WinUI Gallery's Design->Color section
+const platformColorGroups: { header: string; colors: string[] }[] = [
+  {
+    header: 'Control Fill',
+    colors: [
+      'ControlFillColorDefault',
+      'ControlFillColorSecondary',
+      'ControlFillColorTertiary',
+      'ControlFillColorDisabled',
+      'ControlFillColorTransparent',
+    ],
+  },
+  {
+    header: 'Control Alt Fill',
+    colors: [
+      'ControlAltFillColorSecondary',
+      'ControlAltFillColorTertiary',
+      'ControlAltFillColorQuarternary',
+      'ControlAltFillColorDisabled',
+    ],
+  },
+  {
+    header: 'Strong Fill',
+    colors: [
+      'ControlStrongFillColorDefault',
+      'ControlStrongFillColorDisabled',
+    ],
+  },
+  {
+    header: 'Subtle Fill',
+    colors: [
+      'SubtleFillColorTransparent',
+      'SubtleFillColorSecondary',
+    ],
+  },
+  {
+    header: 'Accent Fill',
+    colors: [
+      'SystemAccentColor',
+      'AccentFillColorDisabled',
+    ],
+  },
+  {
+    header: 'Text',
+    colors: [
+      'TextFillColorPrimary',
+      'TextFillColorSecondary',
+      'TextFillColorDisabled',
+    ],
+  },
+  {
+    header: 'Text On Accent',
+    colors: [
+      'TextOnAccentFillColorPrimary',
+      'TextOnAccentFillColorDisabled',
+    ],
+  },
+  {
+    header: 'Control Stroke',
+    colors: [
+      'ControlStrokeColorDefault',
+      'ControlStrokeColorSecondary',
+      'ControlStrokeColorOnAccentSecondary',
+      'ControlStrongStrokeColorDefault',
+      'ControlStrongStrokeColorDisabled',
+    ],
+  },
+  {
+    header: 'Other',
+    colors: [
+      'SolidBackgroundFillColorBase',
+      'TextControlForeground',
+      'ScrollBarButtonBackground',
+      'ScrollBarButtonBackgroundPointerOver',
+      'ScrollBarButtonBackgroundPressed',
+      'ScrollBarButtonBackgroundDisabled',
+      'ScrollBarButtonArrowForeground',
+      'ScrollBarButtonArrowForegroundPointerOver',
+      'ScrollBarButtonArrowForegroundPressed',
+      'ScrollBarButtonArrowForegroundDisabled',
+      'ScrollBarThumbFill',
+      'ScrollBarThumbFillPointerOver',
+      'ScrollBarThumbFillPressed',
+      'ScrollBarThumbFillDisabled',
+      'ScrollBarTrackFill',
+      'ToolTipBackground',
+      'ToolTipForeground',
+      'ToolTipBorderBrush',
+      'SystemChromeMediumLowColor'
+    ],
+  },
+];
+
+
+function PlatformColorList() {
+  const scrollChildren = [];
+  const stickyHeaderIndices = [];
+  let childIndex = 0;
+  for (const group of platformColorGroups) {
+    stickyHeaderIndices.push(childIndex);
+    scrollChildren.push(
+      <Text key={group.header} style={styles.sectionHeader}>{group.header}</Text>
+    );
+    childIndex++;
+    for (const colorKey of group.colors) {
+      scrollChildren.push(
+        <PlatformColorVisualizer key={colorKey} colorKey={colorKey} />
+      );
+      childIndex++;
+    }
+  }
+
+  return (
+    <ScrollView contentContainerStyle={styles.scrollContent}>
+      {scrollChildren}
+    </ScrollView>
+  );
+}
+
+export const PlatformColorExamplePage: React.FunctionComponent<{}> = () => {
+  const example1jsx = `<View
+  style={{
+    backgroundColor: PlatformColor('SystemAccentColor'),
+    padding: 20,
+    borderRadius: 8,
+  }}>
+  <Text style={{
+    color: PlatformColor('TextOnAccentFillColorPrimary'),
+    textAlign: 'center'
+    }}>
+    System Accent Color
+  </Text>
+</View>`;
+
+  return (
+    <Page
+      title="PlatformColor"
+      description="PlatformColor lets you reference the platform's color system. On Windows, you can reference system colors that automatically adapt to the user's theme and accessibility settings."
+      componentType="Core"
+      pageCodeUrl="https://github.com/microsoft/react-native-gallery/blob/main/src/examples/PlatformColorExamplePage.tsx"
+      documentation={[
+        {
+          label: 'PlatformColor',
+          url: 'https://reactnative.dev/docs/platformcolor',
+        },
+        {
+          label: 'Windows System Colors',
+          url: 'https://docs.microsoft.com/en-us/windows/apps/design/style/color',
+        },
+      ]}>
+      <Example title="PlatformColor example" code={example1jsx}>
+        <View
+          style={{
+            backgroundColor: PlatformColor('SystemAccentColor'),
+            padding: 20,
+            borderRadius: 8,
+          }}>
+          <Text style={{color: PlatformColor('TextOnAccentFillColorPrimary'), textAlign: 'center'}}>
+            System Accent Color
+          </Text>
+        </View>
+      </Example>
+
+      <Example title="Available color values" code="// Use PlatformColor with any of the values above">
+        <PlatformColorList />
+      </Example>
+    </Page>
+  );
+};
+
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    gap: 8,
+    alignItems: 'flex-start',
+  },
+  sectionHeader: {
+    fontWeight: '600',
+    fontSize: 16,
+    marginTop: 16,
+    marginBottom: 4,
+  },
+  colorText: {
+    paddingTop: 6,
+    paddingBottom: 4,
+    paddingHorizontal: 14,
+    borderRadius: 6,
+    color: '#fff',
+    fontSize: 15,
+    overflow: 'hidden',
+  },
+});


### PR DESCRIPTION
## Description

Adds a page to React Native Gallery (both Paper and Fabric versions) for viewing valid `PlatformColor` values (and example usage).

### Why

1. It's hard to know what `PlatformColor` values you can use. The way I generally do it is through reading the [Theme.cpp implementation](https://github.com/microsoft/react-native-windows/blob/63e9eaaa2249c3f7b46200203cb69c006c5770a9/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.cpp).
2. The WinUI gallery has a lovely Colors page that is worth adapting into the React Native space (see #437)

### What

Adds a page that provides the following:
- A simple example with sample code of doing accent color foreground/background
- A list valid PlatformColors with names and visible examples
- Those values are grouped by usage (similar to WinUI Gallery's Colors page), with a pivot to move between
- Those values are grouped by type (similar to WinUI Gallery's Colors page)
- You can see those colors over either a light or dark background

Future improvements
- Easy copy button to copy names out
- More closely match the big blocky card visual style of the WinUI Gallery's Colors page
- Track down and fix all PlatformColor values that _should_ be working (based on the code) but aren't...

## Screenshots

Note that there are different valid `PlatformColor` constants on Paper vs. Fabric, which is part of why I wrote this page.

### Paper

https://github.com/user-attachments/assets/925de425-37f6-4fa6-9ec9-8f69379e5d54

### Fabric

https://github.com/user-attachments/assets/c77a075c-e893-490f-a7ba-21fc8f8b433e

