### PR TITLE
fix for accessing flatlist items using keyboard

### DIFF
--- a/NewArch/src/examples/FlatListExamplePage.tsx
+++ b/NewArch/src/examples/FlatListExamplePage.tsx
@@ -138,22 +138,6 @@ export const FlatListExamplePage: React.FunctionComponent<{navigation?: any}> = 
   keyExtractor={(item) => item.id}
   numColumns={3}/>`;
 
-  const renderItem = ({item}: {item: any}) => (
-    <Pressable
-      style={{padding: 5}}
-      accessibilityRole="button"
-      accessibilityLabel={`List item: ${item.title}`}
-      onPress={() => {
-        // Handle item selection - for demo purposes, could show selection state
-        console.log(`Selected: ${item.title}`);
-      }}
-      onAccessibilityTap={() => {
-        console.log(`Accessibility tap: ${item.title}`);
-      }}>
-      <Text style={{color: colors.text}}>{item.title}</Text>
-    </Pressable>
-  );
-
   // Create a specialized render function for the fixed-height example to improve accessibility
   const renderAccessibleItem = ({item}: {item: any}) => (
     <Pressable


### PR DESCRIPTION
## Description
Unable to access all the list items under 'A flatlist inside a fixed-height view'
or any heading for that matter. 

### Why

"A FlatList inside of a fixed-height view" which uses style = {height: 50}. This creates a very short container that only shows a few items, but the FlatList items are not keyboard accessible because:

The items are rendered as <Text> elements without proper accessibility props
The renderItem function doesn't make items focusable
There's no keyboard navigation support for the items

### What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Users who rely on keyboard, will face difficulty in accessing the list items if it is not keyboard accessible.

Resolves [https://github.com/microsoft/react-native-gallery/issues/711]

### What
1. Enhanced Item Accessibility
2. Improved Fixed-Height Container
3.  Comprehensive Accessibility Features Added:
4. Applied to all examples

## Screenshots
Before
<img width="1248" height="498" alt="711-before" src="https://github.com/user-attachments/assets/7e7a8292-3b93-4b64-b833-d3147d702014" />

After
<img width="980" height="856" alt="711-after" src="https://github.com/user-attachments/assets/e6ee4c9c-9793-419c-8189-90c780959d89" />

Video After

https://github.com/user-attachments/assets/0650e69c-c271-43b5-8d0d-01d6c2b39da3



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/712)