### PR TITLE
removing unnecessray statement by narrator on clicking hamburger button

### DIFF
--- a/NewArch/src/App.tsx
+++ b/NewArch/src/App.tsx
@@ -357,7 +357,6 @@ function CustomDrawerContent({ navigation }: { navigation: any }) {
         ref={hamburgerRef}
         accessibilityRole="button"
         accessibilityLabel="Navigation menu"
-        accessibilityHint={'Tap to collapse navigation menu'}
         style={styles.menu}
         onPress={() => {
           if (isDrawerOpen) {


### PR DESCRIPTION
## Description

When user navigates to the 'Navigation menu' button in expanded state, Narrator announces an unnecessary collapse instruction which is not required. It is announcing as "Navigation menu, button, expanded, Tap to collapse navigation menu,".
Expected Result:
When user navigates to the to the Navigation menu button in expanded state, Narrator should only announce the , , <expand/collapse> state information
Instruction is not required to collapsed the 'Navigation menu' button

### Why

Users who rely on Screen reader will face difficulty, if Narrator is announcing the collapse state instruction while navigation to 'Navigation menu' button which is not required

Resolves [https://github.com/microsoft/react-native-gallery/issues/714]

### What

When user navigates to the 'Navigation menu' button in expanded state, Narrator announces an unnecessary collapse instruction which is not required. It is announcing as "Navigation menu, button, expanded, Tap to collapse navigation menu,".
Expected Result:
When user navigates to the to the Navigation menu button in expanded state, Narrator should only announce the , , <expand/collapse> state information
Instruction is not required to collapsed the 'Navigation menu' button

## Screenshots

Before


https://github.com/user-attachments/assets/60be2f37-aa24-4c86-95d2-a4f8e5480122



After

https://github.com/user-attachments/assets/268321fb-3bd4-4a07-b253-58cc19287097

Narrator is no longer announcing 'Tap to collapse navigation menu'


