### PR TITLE
On expanding/collapsing any button present in left navigation bar, Narrator remains silent.

### DIFF
--- a/NewArch/src/App.tsx
+++ b/NewArch/src/App.tsx
@@ -174,6 +174,8 @@ type DrawerCollapsibleCategoryProps = {
   navigation: any;
   currentRoute: string;
   containsCurrentRoute: boolean;
+  positionInSet?: number;
+  setSize?: number;
 };
 const DrawerCollapsibleCategory = ({
   categoryLabel,
@@ -182,6 +184,8 @@ const DrawerCollapsibleCategory = ({
   navigation,
   currentRoute,
   containsCurrentRoute,
+  positionInSet,
+  setSize,
 }: DrawerCollapsibleCategoryProps) => {
   const categoryRoute = `Category: ${categoryLabel}`;
   const isCurrentRoute = currentRoute === categoryRoute;
@@ -231,14 +235,15 @@ const DrawerCollapsibleCategory = ({
         onHoverIn={() => setIsHovered(true)}
         onHoverOut={() => setIsHovered(false)}
         accessibilityRole="button"
-        accessibilityLabel={categoryLabel}
+        accessibilityLabel={`${categoryLabel}, ${isExpanded ? 'expanded' : 'collapsed'}`}
         accessibilityState={{expanded: isExpanded}}
+        {...(positionInSet && setSize ? {accessibilityPosInSet: positionInSet, accessibilitySetSize: setSize} : {})}
         accessibilityActions={[
           {name: isExpanded ? 'collapse' : 'expand', label: isExpanded ? 'Collapse' : 'Expand'},
         ]}
         onAccessibilityAction={(event) => {
           if (event.nativeEvent.actionName === 'expand' || event.nativeEvent.actionName === 'collapse') {
-        setIsExpanded(!isExpanded);
+            setIsExpanded(!isExpanded);
           }
         }}
         onAccessibilityTap={() => onPress()}
@@ -304,7 +309,7 @@ const DrawerListView = (props: {
 
   return (
     <View>
-      {RNGalleryCategories.map((category) => (
+      {RNGalleryCategories.map((category, index) => (
         <DrawerCollapsibleCategory
           key={category.label}
           categoryLabel={category.label}
@@ -313,6 +318,8 @@ const DrawerListView = (props: {
           navigation={props.navigation}
           currentRoute={props.currentRoute}
           containsCurrentRoute={categoryWithCurrentRoute === category.label}
+          positionInSet={index + 1}
+          setSize={RNGalleryCategories.length}
         />
       ))}
     </View>


### PR DESCRIPTION
## Description
Fixes accessibility issue where Windows Narrator does not announce expand/collapse state changes when interacting with navigation drawer category buttons.

### Why
When users interact with collapsible category buttons in the left navigation drawer (e.g., "Basic Input", "Components"), Windows Narrator was not announcing the state change from "collapsed" to "expanded" or vice versa.


### What

1.Added accessibility position and count information
Narrator now announces "1 of 5", "2 of 5", etc., helping users understand their position in the category list
2.Implemented dynamic accessibility label
When state changes, the label change triggers Narrator to announce the new state
## Screenshots


https://github.com/user-attachments/assets/2f28825c-083c-46c5-a6a4-c8cce6580aa6


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/720)