### PR TITLE
Adding fix for close modal not working correctly

### DIFF
--- a/NewArch/src/components/ScreenWrapper.tsx
+++ b/NewArch/src/components/ScreenWrapper.tsx
@@ -67,7 +67,7 @@ export function ScreenWrapper({
         // accessibilityRole="button"
         accessibilityLabel="Navigation bar"
         accessibilityState={{ expanded: isDrawerOpen }}
-        accessibilityLiveRegion='assertive'  
+        accessibilityLiveRegion='assertive'
         // accessibilityHint={isDrawerOpen ? 'Tap to collapse navigation menu' : 'Tap to expand navigation menu'}
         // tooltip={isDrawerOpen ? 'Tap to collapse navigation menu' : 'Tap to expand navigation menu'}
         // requires react-native-gesture-handler to be imported in order to pass testing.


### PR DESCRIPTION
## Description
[Bug bash] Close modal not working correctly

### Why

Close modal not working properly, there is a X button on clicking on open modal, but on clicking the X button, the modal does not close, it only closes on clicking on close modal button

Resolves [https://github.com/microsoft/react-native-gallery/issues/727]

### What

Close modal not working properly, there is a X button on clicking on open modal, but on clicking the X button, the modal does not close, it only closes on clicking on close modal button

## Screenshots

Before


https://github.com/user-attachments/assets/220cf7a5-7c2a-48e4-8b95-3beaa207720b


After

https://github.com/user-attachments/assets/828f8611-7ba9-4f3b-b5f7-d56481405d1b



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/732)