### PR TITLE
Publish new gallery app with latest commit version

### DIFF
--- a/NewArch/package.json
+++ b/NewArch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NewArch",
-  "version": "0.0.1",
+  "version": "2.0.4.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/NewArch/src/SettingsPage.tsx
+++ b/NewArch/src/SettingsPage.tsx
@@ -96,7 +96,7 @@ export const SettingsPage: React.FunctionComponent<{}> = () => {
             To clone this source repository: git clone
             https://github.com/microsoft/react-native-gallery
           </Text>
-          <Text style={styles.text}>Version: 1.0.18.0</Text>
+          <Text style={styles.text}>Version: {pkg.version}</Text>
           <Text style={styles.text}>
             React Native Windows Version:{' '}
             {pkg.dependencies['react-native-windows']}

--- a/NewArch/windows/NewArch.Package/Package.appxmanifest
+++ b/NewArch/windows/NewArch.Package/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="Microsoft.ReactNativeGallery-Experimental"
     Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
-    Version="2.0.3.0" />
+    Version="2.0.4.0" />
 
   <Properties>
     <DisplayName>React Native Gallery - Preview</DisplayName>


### PR DESCRIPTION
## Description

### Why

Publish new gallery app with latest commit version.

Resolves #740

### What

Upgraded Gallery New Arch.

## Screenshots
<img width="984" height="746" alt="image" src="https://github.com/user-attachments/assets/9b09f9e8-d6a0-4915-a9ab-ea721a81ece2" />

Add any relevant screen captures here from before or after your changes. 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/741)