### PR TITLE
Adding Modal from react-native-windows so that onRequestClose can be removed

### DIFF
--- a/NewArch/src/examples/ModalExamplePage.tsx
+++ b/NewArch/src/examples/ModalExamplePage.tsx
@@ -273,7 +273,6 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.25,
     shadowRadius: 4,
     elevation: 5,
-    position: 'relative',
   },
   simpleModalText: {
     color: 'black',


### PR DESCRIPTION
## Description
Modal with complex styling has extended white background, Adding flex to css styling. 

### Why
Adding Flex to fix the issue of Modal with complex styling has extended white background


Resolves [https://github.com/microsoft/react-native-windows/issues/15214?reload=1?reload=1]

### What

Modal with complex styling has extended white background, Adding flex to css styling. 

## Screenshots

Before
<img width="367" height="368" alt="15124-before" src="https://github.com/user-attachments/assets/f87d4fa1-097e-4c76-9933-06b0ef2fd227" />
After
<img width="908" height="1277" alt="15124-after" src="https://github.com/user-attachments/assets/fa1afc78-a472-43c3-bd02-e5865a00294f" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/744)