### PR TITLE
adding auto scroll feature of tab focus on expanded navigation bar

### DIFF
--- a/NewArch/src/components/ScreenWrapper.tsx
+++ b/NewArch/src/components/ScreenWrapper.tsx
@@ -101,7 +101,6 @@ export function ScreenWrapper({
         accessibilityLabel="Navigation bar"
         accessibilityState={{ expanded: isDrawerOpen }}
         accessibilityLiveRegion='assertive'
-        
         // accessibilityHint={isDrawerOpen ? 'Tap to collapse navigation menu' : 'Tap to expand navigation menu'}
         // tooltip={isDrawerOpen ? 'Tap to collapse navigation menu' : 'Tap to expand navigation menu'}
         // requires react-native-gesture-handler to be imported in order to pass testing.


### PR DESCRIPTION
## Description
While navigating between the expanded buttons present in left navigation bar , page is not getting auto scrolled and active focused elements are not visible clearly to the user.

### Why

While navigating between the expanded buttons present in left navigation bar , page is not getting auto scrolled and active focused elements are not visible clearly to the user.

Resolves [https://github.com/microsoft/react-native-gallery/issues/742]

### What

Added ScrollView component and wrapped DrawerComponent using ScrollView

## Screenshots

Before


https://github.com/user-attachments/assets/50949d92-dbf3-4e0e-a59b-a44aed106cb4



After

https://github.com/user-attachments/assets/42856f01-5390-4b6c-840a-c1ce1341b620


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/745)