### PR TITLE
Update react-native-windows to preview.10

### DIFF
--- a/NewArch/package.json
+++ b/NewArch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NewArch",
-  "version": "2.0.5.0",
+  "version": "2.0.6.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",
@@ -16,7 +16,7 @@
     "lowlight": "^1.17.0",
     "react": "19.1.0",
     "react-native": "^0.80.2",
-    "react-native-windows": "^0.80.0-preview.8"
+    "react-native-windows": "^0.80.0-preview.10"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/NewArch/windows/NewArch.Package/Package.appxmanifest
+++ b/NewArch/windows/NewArch.Package/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="Microsoft.ReactNativeGallery-Experimental"
     Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
-    Version="2.0.5.0" />
+    Version="2.0.6.0" />
 
   <Properties>
     <DisplayName>React Native Gallery - Preview</DisplayName>

--- a/NewArch/windows/NewArch/packages.lock.json
+++ b/NewArch/windows/NewArch/packages.lock.json
@@ -16,17 +16,17 @@
       },
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.80.0-preview.8, )",
-        "resolved": "0.80.0-preview.8",
-        "contentHash": "YbN4cKio45ngm0e5wjYjx9vRPmpWJ3lM2WdOAKfj+v42PzwCBVVAMIIOp0g2AscP6W8X6sj4jO3If6Csn8rTfA=="
+        "requested": "[0.80.0-preview.10, )",
+        "resolved": "0.80.0-preview.10",
+        "contentHash": "6ypTdOPeoz6Il358xDMyY8jZUWgB4QceY/xvPpHEvn/DRIDfdKYSwZE6o84JVyuO4KEKJpmV4VswA59RG5wwCA=="
       },
       "Microsoft.ReactNative.Cxx": {
         "type": "Direct",
-        "requested": "[0.80.0-preview.8, )",
-        "resolved": "0.80.0-preview.8",
-        "contentHash": "xnDJDkoMIxTXVBH9wAnstJWgNUkwpt7hBG8iGQkQawY5yxWwFd73RjfN28rx+lroQp1oPIu/XfAht0Jhjl17VA==",
+        "requested": "[0.80.0-preview.10, )",
+        "resolved": "0.80.0-preview.10",
+        "contentHash": "6VmKCrc/41tiTrYGWiCf5Pw75LQxcJ7QFmG7wIaEomUSOg3sWlgz797sBY0hyqVAC7ASw6R4IXfx4J+Ui6TGLA==",
         "dependencies": {
-          "Microsoft.ReactNative": "0.80.0-preview.8"
+          "Microsoft.ReactNative": "0.80.0-preview.10"
         }
       },
       "Microsoft.VCRTForwarders.140": {
@@ -64,8 +64,8 @@
       "clipboard": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.ReactNative": "[0.80.0-preview.8, )",
-          "Microsoft.ReactNative.Cxx": "[0.80.0-preview.8, )",
+          "Microsoft.ReactNative": "[0.80.0-preview.10, )",
+          "Microsoft.ReactNative.Cxx": "[0.80.0-preview.10, )",
           "Microsoft.VCRTForwarders.140": "[1.0.2-rc, )",
           "Microsoft.WindowsAppSDK": "[1.7.250401001, )",
           "boost": "[1.83.0, )"
@@ -75,9 +75,9 @@
     "native,Version=v0.0/win": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.80.0-preview.8, )",
-        "resolved": "0.80.0-preview.8",
-        "contentHash": "YbN4cKio45ngm0e5wjYjx9vRPmpWJ3lM2WdOAKfj+v42PzwCBVVAMIIOp0g2AscP6W8X6sj4jO3If6Csn8rTfA=="
+        "requested": "[0.80.0-preview.10, )",
+        "resolved": "0.80.0-preview.10",
+        "contentHash": "6ypTdOPeoz6Il358xDMyY8jZUWgB4QceY/xvPpHEvn/DRIDfdKYSwZE6o84JVyuO4KEKJpmV4VswA59RG5wwCA=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -104,9 +104,9 @@
     "native,Version=v0.0/win-arm64": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.80.0-preview.8, )",
-        "resolved": "0.80.0-preview.8",
-        "contentHash": "YbN4cKio45ngm0e5wjYjx9vRPmpWJ3lM2WdOAKfj+v42PzwCBVVAMIIOp0g2AscP6W8X6sj4jO3If6Csn8rTfA=="
+        "requested": "[0.80.0-preview.10, )",
+        "resolved": "0.80.0-preview.10",
+        "contentHash": "6ypTdOPeoz6Il358xDMyY8jZUWgB4QceY/xvPpHEvn/DRIDfdKYSwZE6o84JVyuO4KEKJpmV4VswA59RG5wwCA=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -133,9 +133,9 @@
     "native,Version=v0.0/win-x64": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.80.0-preview.8, )",
-        "resolved": "0.80.0-preview.8",
-        "contentHash": "YbN4cKio45ngm0e5wjYjx9vRPmpWJ3lM2WdOAKfj+v42PzwCBVVAMIIOp0g2AscP6W8X6sj4jO3If6Csn8rTfA=="
+        "requested": "[0.80.0-preview.10, )",
+        "resolved": "0.80.0-preview.10",
+        "contentHash": "6ypTdOPeoz6Il358xDMyY8jZUWgB4QceY/xvPpHEvn/DRIDfdKYSwZE6o84JVyuO4KEKJpmV4VswA59RG5wwCA=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -162,9 +162,9 @@
     "native,Version=v0.0/win-x86": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.80.0-preview.8, )",
-        "resolved": "0.80.0-preview.8",
-        "contentHash": "YbN4cKio45ngm0e5wjYjx9vRPmpWJ3lM2WdOAKfj+v42PzwCBVVAMIIOp0g2AscP6W8X6sj4jO3If6Csn8rTfA=="
+        "requested": "[0.80.0-preview.10, )",
+        "resolved": "0.80.0-preview.10",
+        "contentHash": "6ypTdOPeoz6Il358xDMyY8jZUWgB4QceY/xvPpHEvn/DRIDfdKYSwZE6o84JVyuO4KEKJpmV4VswA59RG5wwCA=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",

--- a/NewArch/yarn.lock
+++ b/NewArch/yarn.lock
@@ -2410,9 +2410,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-windows/cli@npm:0.80.0-preview.6":
-  version: 0.80.0-preview.6
-  resolution: "@react-native-windows/cli@npm:0.80.0-preview.6"
+"@react-native-windows/cli@npm:0.80.0-preview.7":
+  version: 0.80.0-preview.7
+  resolution: "@react-native-windows/cli@npm:0.80.0-preview.7"
   dependencies:
     "@react-native-windows/codegen": "npm:0.80.0-preview.1"
     "@react-native-windows/fs": "npm:0.80.0-preview.1"
@@ -2437,7 +2437,7 @@ __metadata:
     xpath: "npm:^0.0.27"
   peerDependencies:
     react-native: "*"
-  checksum: 10c0/a2b2a14d926c0f7d01548d20a14f5848f0d7cb136bf94529bc6fcd6505dfefb72e8a7b2f32db700414de29a77793a59bc58a9a223bc5d68c1ef8be596e4db661
+  checksum: 10c0/bb55370c20012a894516876450b4d3a45873ef139e6b6e13be94c35ea8faf5bca81d4aaed489f1e12814013c8a9420ed5c4f846e8e352aab4e28ab75d6551c70
   languageName: node
   linkType: hard
 
@@ -3320,7 +3320,7 @@ __metadata:
     prettier: "npm:2.8.8"
     react: "npm:19.1.0"
     react-native: "npm:^0.80.2"
-    react-native-windows: "npm:^0.80.0-preview.8"
+    react-native-windows: "npm:^0.80.0-preview.10"
     react-test-renderer: "npm:19.1.0"
     typescript: "npm:5.0.4"
   languageName: unknown
@@ -8531,16 +8531,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-windows@npm:^0.80.0-preview.8":
-  version: 0.80.0-preview.8
-  resolution: "react-native-windows@npm:0.80.0-preview.8"
+"react-native-windows@npm:^0.80.0-preview.10":
+  version: 0.80.0-preview.10
+  resolution: "react-native-windows@npm:0.80.0-preview.10"
   dependencies:
     "@babel/runtime": "npm:^7.0.0"
     "@jest/create-cache-key-function": "npm:^29.7.0"
     "@react-native-community/cli": "npm:17.0.0"
     "@react-native-community/cli-platform-android": "npm:17.0.0"
     "@react-native-community/cli-platform-ios": "npm:17.0.0"
-    "@react-native-windows/cli": "npm:0.80.0-preview.6"
+    "@react-native-windows/cli": "npm:0.80.0-preview.7"
     "@react-native/assets": "npm:1.0.0"
     "@react-native/assets-registry": "npm:0.80.0"
     "@react-native/codegen": "npm:0.80.0"
@@ -8584,7 +8584,7 @@ __metadata:
     "@types/react": ^19.1.0
     react: ^19.1.0
     react-native: ^0.80.0
-  checksum: 10c0/fbc3b827fdde1a85fa50112c026b7ce51c5ed11aa94f5bb9b7d299358cd5d61ddf42a52b4b5f3001283b1304cb9f6a525a5d112ab505728cd809702414535f06
+  checksum: 10c0/a154b839844dc310a3f7cf6bcba4f385f7bc3f33355df7d5ce8176b7d007bf1d073f43681a8fbad454eab3c0929ba4494cdbe95b3aff8aa8258c0f2d7766238c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bump react-native-windows and related dependencies from 0.80.0-preview.8 to 0.80.0-preview.10 in package.json, yarn.lock, and packages.lock.json. Also update app version to 2.0.6.0 in package.json and Package.appxmanifest.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/747)