### PR TITLE
Update to react-native-windows 0.80.0 and app branding

### DIFF
--- a/NewArch/package.json
+++ b/NewArch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NewArch",
-  "version": "2.0.6.0",
+  "version": "2.0.7.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",
@@ -16,7 +16,7 @@
     "lowlight": "^1.17.0",
     "react": "19.1.0",
     "react-native": "^0.80.2",
-    "react-native-windows": "^0.80.0-preview.10"
+    "react-native-windows": "^0.80.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/NewArch/windows/NewArch.Package/Package.appxmanifest
+++ b/NewArch/windows/NewArch.Package/Package.appxmanifest
@@ -9,10 +9,10 @@
   <Identity
     Name="Microsoft.ReactNativeGallery-Experimental"
     Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
-    Version="2.0.6.0" />
+    Version="2.0.7.0" />
 
   <Properties>
-    <DisplayName>React Native Gallery - Preview</DisplayName>
+    <DisplayName>React Native Gallery</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>
@@ -31,8 +31,8 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="NewArch.App">
       <uap:VisualElements
-        DisplayName="React Native Gallery - Preview"
-        Description="React Native Gallery - Preview [New Architecture]"
+        DisplayName="React Native Gallery"
+        Description="React Native Gallery [New Architecture]"
         BackgroundColor="transparent"
         Square150x150Logo="Images\Square150x150Logo.png"
         Square44x44Logo="Images\Square44x44Logo.png">

--- a/NewArch/windows/NewArch/NewArch.cpp
+++ b/NewArch/windows/NewArch/NewArch.cpp
@@ -70,7 +70,7 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR 
 
   // Get the AppWindow so we can configure its initial title and size
   auto appWindow{reactNativeWin32App.AppWindow()};
-  appWindow.Title(L"React Native Gallery - Preview");
+  appWindow.Title(L"React Native Gallery");
   appWindow.Resize({1000, 1000});
 
   // Configure title bar to respect system theme (dark mode support)

--- a/NewArch/windows/NewArch/packages.lock.json
+++ b/NewArch/windows/NewArch/packages.lock.json
@@ -16,17 +16,17 @@
       },
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.80.0-preview.10, )",
-        "resolved": "0.80.0-preview.10",
-        "contentHash": "6ypTdOPeoz6Il358xDMyY8jZUWgB4QceY/xvPpHEvn/DRIDfdKYSwZE6o84JVyuO4KEKJpmV4VswA59RG5wwCA=="
+        "requested": "[0.80.0, )",
+        "resolved": "0.80.0",
+        "contentHash": "YgNOIykU9Q12e7qI/EPID4GxkQ/CChoNrkU5iA8UOLXlLRoDyUdjIKzjI4l2EIG7tNWBezzt4y0vfUx+O3N5Dw=="
       },
       "Microsoft.ReactNative.Cxx": {
         "type": "Direct",
-        "requested": "[0.80.0-preview.10, )",
-        "resolved": "0.80.0-preview.10",
-        "contentHash": "6VmKCrc/41tiTrYGWiCf5Pw75LQxcJ7QFmG7wIaEomUSOg3sWlgz797sBY0hyqVAC7ASw6R4IXfx4J+Ui6TGLA==",
+        "requested": "[0.80.0, )",
+        "resolved": "0.80.0",
+        "contentHash": "097y6EeB13QEnjnDGlDnTY2gZKVMYP1pUSmH7ERu/Ei4H6DOwcmELfhOcrelv+W2oG9E8EwPYkl0OvoQKpUwuA==",
         "dependencies": {
-          "Microsoft.ReactNative": "0.80.0-preview.10"
+          "Microsoft.ReactNative": "0.80.0"
         }
       },
       "Microsoft.VCRTForwarders.140": {
@@ -64,8 +64,8 @@
       "clipboard": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.ReactNative": "[0.80.0-preview.10, )",
-          "Microsoft.ReactNative.Cxx": "[0.80.0-preview.10, )",
+          "Microsoft.ReactNative": "[0.80.0, )",
+          "Microsoft.ReactNative.Cxx": "[0.80.0, )",
           "Microsoft.VCRTForwarders.140": "[1.0.2-rc, )",
           "Microsoft.WindowsAppSDK": "[1.7.250401001, )",
           "boost": "[1.83.0, )"
@@ -75,9 +75,9 @@
     "native,Version=v0.0/win": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.80.0-preview.10, )",
-        "resolved": "0.80.0-preview.10",
-        "contentHash": "6ypTdOPeoz6Il358xDMyY8jZUWgB4QceY/xvPpHEvn/DRIDfdKYSwZE6o84JVyuO4KEKJpmV4VswA59RG5wwCA=="
+        "requested": "[0.80.0, )",
+        "resolved": "0.80.0",
+        "contentHash": "YgNOIykU9Q12e7qI/EPID4GxkQ/CChoNrkU5iA8UOLXlLRoDyUdjIKzjI4l2EIG7tNWBezzt4y0vfUx+O3N5Dw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -104,9 +104,9 @@
     "native,Version=v0.0/win-arm64": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.80.0-preview.10, )",
-        "resolved": "0.80.0-preview.10",
-        "contentHash": "6ypTdOPeoz6Il358xDMyY8jZUWgB4QceY/xvPpHEvn/DRIDfdKYSwZE6o84JVyuO4KEKJpmV4VswA59RG5wwCA=="
+        "requested": "[0.80.0, )",
+        "resolved": "0.80.0",
+        "contentHash": "YgNOIykU9Q12e7qI/EPID4GxkQ/CChoNrkU5iA8UOLXlLRoDyUdjIKzjI4l2EIG7tNWBezzt4y0vfUx+O3N5Dw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -133,9 +133,9 @@
     "native,Version=v0.0/win-x64": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.80.0-preview.10, )",
-        "resolved": "0.80.0-preview.10",
-        "contentHash": "6ypTdOPeoz6Il358xDMyY8jZUWgB4QceY/xvPpHEvn/DRIDfdKYSwZE6o84JVyuO4KEKJpmV4VswA59RG5wwCA=="
+        "requested": "[0.80.0, )",
+        "resolved": "0.80.0",
+        "contentHash": "YgNOIykU9Q12e7qI/EPID4GxkQ/CChoNrkU5iA8UOLXlLRoDyUdjIKzjI4l2EIG7tNWBezzt4y0vfUx+O3N5Dw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",
@@ -162,9 +162,9 @@
     "native,Version=v0.0/win-x86": {
       "Microsoft.ReactNative": {
         "type": "Direct",
-        "requested": "[0.80.0-preview.10, )",
-        "resolved": "0.80.0-preview.10",
-        "contentHash": "6ypTdOPeoz6Il358xDMyY8jZUWgB4QceY/xvPpHEvn/DRIDfdKYSwZE6o84JVyuO4KEKJpmV4VswA59RG5wwCA=="
+        "requested": "[0.80.0, )",
+        "resolved": "0.80.0",
+        "contentHash": "YgNOIykU9Q12e7qI/EPID4GxkQ/CChoNrkU5iA8UOLXlLRoDyUdjIKzjI4l2EIG7tNWBezzt4y0vfUx+O3N5Dw=="
       },
       "Microsoft.VCRTForwarders.140": {
         "type": "Direct",

--- a/NewArch/yarn.lock
+++ b/NewArch/yarn.lock
@@ -2410,14 +2410,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-windows/cli@npm:0.80.0-preview.7":
-  version: 0.80.0-preview.7
-  resolution: "@react-native-windows/cli@npm:0.80.0-preview.7"
+"@react-native-windows/cli@npm:0.80.0":
+  version: 0.80.0
+  resolution: "@react-native-windows/cli@npm:0.80.0"
   dependencies:
-    "@react-native-windows/codegen": "npm:0.80.0-preview.1"
-    "@react-native-windows/fs": "npm:0.80.0-preview.1"
-    "@react-native-windows/package-utils": "npm:0.80.0-preview.1"
-    "@react-native-windows/telemetry": "npm:0.80.0-preview.2"
+    "@react-native-windows/codegen": "npm:0.80.0"
+    "@react-native-windows/fs": "npm:0.80.0"
+    "@react-native-windows/package-utils": "npm:0.80.0"
+    "@react-native-windows/telemetry": "npm:0.80.0"
     "@xmldom/xmldom": "npm:^0.7.7"
     chalk: "npm:^4.1.0"
     cli-spinners: "npm:^2.2.0"
@@ -2437,15 +2437,15 @@ __metadata:
     xpath: "npm:^0.0.27"
   peerDependencies:
     react-native: "*"
-  checksum: 10c0/bb55370c20012a894516876450b4d3a45873ef139e6b6e13be94c35ea8faf5bca81d4aaed489f1e12814013c8a9420ed5c4f846e8e352aab4e28ab75d6551c70
+  checksum: 10c0/ee1f0413283b82f023c09be451b00d9b12caad137dfba0e41ed70068c1d3a99cb0e123188c28f3da1bae32fd61b0ac7efaa8f8d3581c79559dbc265fbba8dacb
   languageName: node
   linkType: hard
 
-"@react-native-windows/codegen@npm:0.80.0-preview.1":
-  version: 0.80.0-preview.1
-  resolution: "@react-native-windows/codegen@npm:0.80.0-preview.1"
+"@react-native-windows/codegen@npm:0.80.0":
+  version: 0.80.0
+  resolution: "@react-native-windows/codegen@npm:0.80.0"
   dependencies:
-    "@react-native-windows/fs": "npm:0.80.0-preview.1"
+    "@react-native-windows/fs": "npm:0.80.0"
     chalk: "npm:^4.1.0"
     globby: "npm:^11.1.0"
     mustache: "npm:^4.0.1"
@@ -2455,55 +2455,55 @@ __metadata:
     react-native: "*"
   bin:
     react-native-windows-codegen: bin.js
-  checksum: 10c0/10f3cdb51acbc54f52bff64dab77636ed726c9ecf14fd63c58f0417c4f45b8fa6b149068a548b07adecd48e411023e53d04b790567d33caa2535a5d94352e905
+  checksum: 10c0/dc38d9ee810a5bfd3442341387a8a9943dbfc29d55333fd5434ae7ea349a16bbf4e81670f2802aade1c5a05e21a167b76956916747bf8260265c9dd0aa4d9671
   languageName: node
   linkType: hard
 
-"@react-native-windows/find-repo-root@npm:0.80.0-preview.1":
-  version: 0.80.0-preview.1
-  resolution: "@react-native-windows/find-repo-root@npm:0.80.0-preview.1"
+"@react-native-windows/find-repo-root@npm:0.80.0":
+  version: 0.80.0
+  resolution: "@react-native-windows/find-repo-root@npm:0.80.0"
   dependencies:
-    "@react-native-windows/fs": "npm:0.80.0-preview.1"
+    "@react-native-windows/fs": "npm:0.80.0"
     find-up: "npm:^4.1.0"
-  checksum: 10c0/7ceb0280865eae1af2adc5c267a7565398da6e26540e59d3b34759a894c30c506d323105b6ddc270cb5b103ef66bec638de7f6d24acfd893f66ab40210e15859
+  checksum: 10c0/e31c62d897f334e064a5fa50b6fa58cabbe02affe7e501c4f779232f7e3db9123bd8c3a562dd9604fa9605efab62184d753a26ce7260af83348366edae3ee996
   languageName: node
   linkType: hard
 
-"@react-native-windows/fs@npm:0.80.0-preview.1":
-  version: 0.80.0-preview.1
-  resolution: "@react-native-windows/fs@npm:0.80.0-preview.1"
+"@react-native-windows/fs@npm:0.80.0":
+  version: 0.80.0
+  resolution: "@react-native-windows/fs@npm:0.80.0"
   dependencies:
     graceful-fs: "npm:^4.2.8"
-  checksum: 10c0/20bba450bc7014ba0336378268cd5b024f5537c6f243419fcbb8ebfc5f6d8a71c0ad1e9bf92d495ae42df80001e6a9f995009b1fb5d842401cbc9eb82be71883
+  checksum: 10c0/20d8d69b05de3def4217840ade5c2a8822dab99bd449211d7b3549da4d5d2fa67257fe5ad5f9a115272d552cbe1f92a89603a202b5cae5ec7e1dea2148b3811e
   languageName: node
   linkType: hard
 
-"@react-native-windows/package-utils@npm:0.80.0-preview.1":
-  version: 0.80.0-preview.1
-  resolution: "@react-native-windows/package-utils@npm:0.80.0-preview.1"
+"@react-native-windows/package-utils@npm:0.80.0":
+  version: 0.80.0
+  resolution: "@react-native-windows/package-utils@npm:0.80.0"
   dependencies:
-    "@react-native-windows/find-repo-root": "npm:0.80.0-preview.1"
-    "@react-native-windows/fs": "npm:0.80.0-preview.1"
+    "@react-native-windows/find-repo-root": "npm:0.80.0"
+    "@react-native-windows/fs": "npm:0.80.0"
     get-monorepo-packages: "npm:^1.2.0"
     lodash: "npm:^4.17.15"
-  checksum: 10c0/3587454e667d675f1604ba5a47fe0aa66d86bdf399435df0090f6654a64f33a14e9edd19a17388caa2b9ac5f928f18963d44658d4b724197e4aac80e3122427e
+  checksum: 10c0/2c6ffa7f84562ff68c6917bc47832cbd579da9c9955446a6bfef444b76ff7c39293a41abecf6c8e9f00db7d7cdaf7867e40bf00e9430c1123ff5ca761602ef9e
   languageName: node
   linkType: hard
 
-"@react-native-windows/telemetry@npm:0.80.0-preview.2":
-  version: 0.80.0-preview.2
-  resolution: "@react-native-windows/telemetry@npm:0.80.0-preview.2"
+"@react-native-windows/telemetry@npm:0.80.0":
+  version: 0.80.0
+  resolution: "@react-native-windows/telemetry@npm:0.80.0"
   dependencies:
     "@microsoft/1ds-core-js": "npm:^4.3.0"
     "@microsoft/1ds-post-js": "npm:^4.3.0"
-    "@react-native-windows/fs": "npm:0.80.0-preview.1"
+    "@react-native-windows/fs": "npm:0.80.0"
     "@xmldom/xmldom": "npm:^0.7.7"
     ci-info: "npm:^3.2.0"
     envinfo: "npm:^7.8.1"
     lodash: "npm:^4.17.21"
     os-locale: "npm:^5.0.0"
     xpath: "npm:^0.0.27"
-  checksum: 10c0/1d1a59bb6befdd9e643c204d1831a4d26015665de02775908371889e008f82ec226048271effcfba3364643c1d5fc01b1961e14b23287d67e72b784a9086245a
+  checksum: 10c0/cd82b9793b678fec9c6e4f3cf8f13573bc475ae89ead9cd71e1621f8cff11315f82e2ee56c8d22134efaef2885d4a9c5a86e32ddac102841025dbd43cf479257
   languageName: node
   linkType: hard
 
@@ -3320,7 +3320,7 @@ __metadata:
     prettier: "npm:2.8.8"
     react: "npm:19.1.0"
     react-native: "npm:^0.80.2"
-    react-native-windows: "npm:^0.80.0-preview.10"
+    react-native-windows: "npm:^0.80.0"
     react-test-renderer: "npm:19.1.0"
     typescript: "npm:5.0.4"
   languageName: unknown
@@ -8531,16 +8531,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-windows@npm:^0.80.0-preview.10":
-  version: 0.80.0-preview.10
-  resolution: "react-native-windows@npm:0.80.0-preview.10"
+"react-native-windows@npm:^0.80.0":
+  version: 0.80.0
+  resolution: "react-native-windows@npm:0.80.0"
   dependencies:
     "@babel/runtime": "npm:^7.0.0"
     "@jest/create-cache-key-function": "npm:^29.7.0"
     "@react-native-community/cli": "npm:17.0.0"
     "@react-native-community/cli-platform-android": "npm:17.0.0"
     "@react-native-community/cli-platform-ios": "npm:17.0.0"
-    "@react-native-windows/cli": "npm:0.80.0-preview.7"
+    "@react-native-windows/cli": "npm:0.80.0"
     "@react-native/assets": "npm:1.0.0"
     "@react-native/assets-registry": "npm:0.80.0"
     "@react-native/codegen": "npm:0.80.0"
@@ -8584,7 +8584,7 @@ __metadata:
     "@types/react": ^19.1.0
     react: ^19.1.0
     react-native: ^0.80.0
-  checksum: 10c0/a154b839844dc310a3f7cf6bcba4f385f7bc3f33355df7d5ce8176b7d007bf1d073f43681a8fbad454eab3c0929ba4494cdbe95b3aff8aa8258c0f2d7766238c
+  checksum: 10c0/e09e835f371b4ea31b347cdb87e9f794eeaa1a8fed272a2ebcf48af85d7206979868ce15f02fe8d7600f01f5654a0cbaafa9f6836ba9acc0089900832784fe79
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgraded react-native-windows and related dependencies from 0.80.0-preview.10 to 0.80.0. Updated app version to 2.0.7.0 and removed 'Preview' from app display name, description, and window title for production branding.
<img width="1447" height="1579" alt="image" src="https://github.com/user-attachments/assets/d5e7da33-066e-4f0c-a32f-8b41e76df3fd" />
