### PR TITLE
[DO NOT MERGE] Fix drawer navigation for React Native 0.81 New Architecture

### DIFF
--- a/NewArch/src/Navigation.tsx
+++ b/NewArch/src/Navigation.tsx
@@ -257,44 +257,42 @@ const DrawerNavigator = ({drawerContent, defaultStatus, children} : DrawerNaviga
 
   return (
     <NavigationContext.Provider value={navigation}>
-      <View>
-          <View>
-            { drawerIsOpen &&
-              <Animated.View
-                style={{opacity: fadeAnim}}>
-                <Pressable
-                  style={{
-                    backgroundColor: PlatformColor('Background'),
-                    maxWidth: DEFAULT_DRAWER_WIDTH,
-                    height: '100%',
-                    width: '100%'}}
-                    onPress={() => setDrawerDesiredOpen(false)}
-                    onAccessibilityTap={() => setDrawerDesiredOpen(false)}
-                    />
-              </Animated.View>
-            }
-            <Animated.View
-              style={{
-                position: 'absolute',
-                maxWidth: DEFAULT_DRAWER_WIDTH,
-                height: '100%',
-                width: '100%',
-                transform: [{translateX: slideAnim}]}}
-              >
-              {drawer}
-            </Animated.View>
-          </View>
+      <View style={{flex: 1}}>
         {React.Children.map(children, child => {
           const name = child.props.name;
           if (name !== navigationContext.currentScreen) {
             return null;
           }
           return (
-            <View key={name} style={{alignItems: 'stretch'}}>
+            <View key={name} style={{flex: 1}}>
               {child}
             </View>
           );
         })}
+        { drawerIsOpen &&
+          <Animated.View
+            style={{position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, opacity: fadeAnim}}>
+            <Pressable
+              style={{
+                flex: 1,
+                backgroundColor: PlatformColor('Background')}}
+                onPress={() => setDrawerDesiredOpen(false)}
+                onAccessibilityTap={() => setDrawerDesiredOpen(false)}
+                />
+          </Animated.View>
+        }
+        <Animated.View
+          style={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            left: 0,
+            maxWidth: DEFAULT_DRAWER_WIDTH,
+            width: '100%',
+            transform: [{translateX: slideAnim}]}}
+          >
+          {drawer}
+        </Animated.View>
       </View>
     </NavigationContext.Provider>
   );


### PR DESCRIPTION
## Description

### Why

The drawer navigation (hamburger menu) in the Gallery app became invisible after upgrading to React Native 0.81 with the New Architecture enabled. When clicking the hamburger button, the animation would run but the drawer content was not visible. This was caused by two breaking changes in React Native 0.81:

1. Yoga 3.0 Layout Engine Change: The layout engine now follows strict W3C CSS standards. Using height 100% on absolutely positioned elements resolves to zero when the parent has no explicit height. This made the drawer have zero height and become invisible.
   Reference: https://www.yogalayout.dev/blog/announcing-yoga-3.0
   Reference: https://www.yogalayout.dev/docs/advanced/containing-block

2. Fabric Renderer Stacking Order Change: The new Fabric renderer follows strict DOM render order for visual stacking. Elements rendered later in JSX appear on top. Our drawer was rendered before the main content, so the main content was covering the drawer.
   Reference: https://github.com/facebook/react-native/issues/54174

### What

1. Changed render order: Moved drawer elements to render AFTER the main content children so they appear on top in the new Fabric stacking model.

2. Fixed absolute positioning: Replaced height 100% with top 0 bottom 0 left 0 right 0 for absolute positioned elements. This works reliably in Yoga 3.0 regardless of parent height.

3. Added flex layout: Added flex 1 to root container and child content wrapper to provide proper dimensions for the layout hierarchy.

4. Simplified structure: Removed unnecessary wrapper View that was interfering with the containing block hierarchy.

Backward Compatibility: These changes are backward compatible with React Native 0.80 and earlier versions. The flex and absolute positioning patterns used work identically in older versions.

## Screenshots

