### PR TITLE
[New Arch] Add change to align with RNW metro config

### DIFF
--- a/NewArch/metro.config.js
+++ b/NewArch/metro.config.js
@@ -2,8 +2,6 @@ const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
 
 const fs = require('fs');
 const path = require('path');
-const exclusionList = require('metro-config/src/defaults/exclusionList');
-
 const rnwPath = fs.realpathSync(
   path.resolve(require.resolve('react-native-windows/package.json'), '..'),
 );


### PR DESCRIPTION
## Description
https://github.com/microsoft/react-native-windows/blob/main/vnext/templates/cpp-app/metro.config.js 
Source file

### Why

Metro won't because of the recent modification from meta to remove exclusion list


### What

Removed the import of exclusion list.

## Screenshots
<img width="1092" height="287" alt="image" src="https://github.com/user-attachments/assets/d841818e-f4ec-4dd7-aa73-72d46aa1654b" />

Add any relevant screen captures here from before or after your changes.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/754)