### PR TITLE
adding multiline text input height

### DIFF
--- a/NewArch/src/examples/TextInputExamplePage.tsx
+++ b/NewArch/src/examples/TextInputExamplePage.tsx
@@ -102,14 +102,15 @@ export const TextInputExamplePage: React.FunctionComponent<{navigation?: any}> =
             borderColor: colors.border,
             borderWidth: 1,
             color: colors.text,
-            height: 120,
             paddingHorizontal: 8,
             paddingVertical: 8,
             textAlignVertical: 'top',
+            minHeight: 100,
           }}
           onChangeText={onChangeText2}
           value={text2}
           multiline
+          scrollEnabled={false}
           placeholder="Enter multiline text input here..."
         />
       </Example>


### PR DESCRIPTION
## Description

In multiline text input field while pressing shift+enter for the first time, the cursor was moving to the next line but was not visible 

### Why

To fix the text input and make sure it's properly visible to users

Resolves [https://github.com/microsoft/react-native-windows/issues/15446]

### What

updated the height of the text input and added a new prop textAlignVertical: 'top' which will ensure text starts from the top of the input box

## Screenshots

Before

https://github.com/user-attachments/assets/53e2861a-ae42-4d0c-8924-e1180022195c

after


https://github.com/user-attachments/assets/5286306e-1bf1-4f5b-9759-0ff77dff6c10



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/757)