### PR TITLE
Fix text scaling accessibility for navigation and header.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,7 +144,7 @@ const DrawerListItem = ({
           {icon}
         </Text>
       </View>
-      <Text accessible={false} style={styles.drawerText}>
+      <Text accessible={false} style={styles.drawerText} allowFontScaling={true}>
         {label}
       </Text>
     </Pressable>
@@ -212,7 +212,7 @@ const DrawerCollapsibleCategory = ({
             {categoryIcon}
           </Text>
         </View>
-        <Text accessible={false} style={styles.drawerText}>
+        <Text accessible={false} style={styles.drawerText} allowFontScaling={true}>
           {categoryLabel}
         </Text>
         <View style={styles.expandedChevron}>

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -99,7 +99,8 @@ const PageTitle = () => {
           <Text
             accessible
             accessibilityRole={'header'}
-            style={styles.pageTitle}>
+            style={styles.pageTitle}
+            allowFontScaling={true}>
             React Native Gallery
           </Text>
         </View>


### PR DESCRIPTION
## Description

Adds `allowFontScaling={true}` to navigation panel text and header title to enable proper text scaling when users increase system text size.

### Why

When users set system text scaling to 200% (for low vision accessibility), the following UI elements were not resizing properly:
- Navigation menu items ("Home", "All samples", category labels)
- The "React Native Gallery" header title

This creates a significant accessibility barrier for users who rely on large text for readability.
### What

- **src/App.tsx**: Added `allowFontScaling={true}` to drawer navigation item labels and collapsible category labels
- **src/HomePage.tsx**: Added `allowFontScaling={true}` to "React Native Gallery" page title


## Screenshots

### Before (200% text scaling)
Text in navigation panel does not scale with system settings, causing readability issues for low vision users.

### After (200% text scaling)
Navigation text and header properly scale with system text size settings.

## Testing
1. Set display resolution to 1280x768
2. Increase system text size to 200%
3. Open the application
4. Verify navigation panel text ("Home", "All samples", category items) scales properly
5. Verify "React Native Gallery" header title scales properly


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/762)