### PR TITLE
Fix color contrast for Colored Button example.

### DIFF
--- a/src/examples/ButtonExamplePage.tsx
+++ b/src/examples/ButtonExamplePage.tsx
@@ -47,7 +47,7 @@ export const ButtonExamplePage: React.FunctionComponent<{}> = () => {
           title="Button"
           color={
             Platform.OS === 'windows'
-              ? PlatformColor('SystemBaseLowColor')
+              ? PlatformColor('SystemAccentColor')
               : 'silver'
           }
           accessibilityLabel={'example colored button2'}


### PR DESCRIPTION
## Description

Fixes color contrast issue on the "Colored Button" example in the Button page by changing from `SystemBaseLowColor` to `SystemAccentColor`.

### Why

The "Colored Button" example was using `PlatformColor('SystemBaseLowColor')` which resulted in a contrast ratio of 3.56:1 - below the minimum required 4.5:1 for normal text. This made the button label difficult to read for users with low vision or contrast sensitivity.

### What

- **src/examples/ButtonExamplePage.tsx**: Changed button color from `SystemBaseLowColor` to `SystemAccentColor`

### Screenshot
## Before 
<img width="941" height="487" alt="before_button" src="https://github.com/user-attachments/assets/9da637e9-22d4-4325-98fb-7de455d6898d" />

## After
<img width="944" height="485" alt="button_after" src="https://github.com/user-attachments/assets/1bd4979f-b6c4-48ee-b5eb-c235fa4b39d9" />

## Testing
1. Open the application
2. Navigate to 'Button' page
3. Check the "Colored Button" example
4. Verify text contrast ratio meets 4.5:1 minimum


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/763)