### PR TITLE
Add light mode support for button color

### DIFF
--- a/NewArch/src/examples/ButtonExamplePage.tsx
+++ b/NewArch/src/examples/ButtonExamplePage.tsx
@@ -9,7 +9,7 @@ import {useTheme} from '../Navigation';
 export const ButtonExamplePage: React.FunctionComponent<{route?: any; navigation?: any}> = ({navigation}) => {
   const [title, setTitle] = useState(0);
   const [windowDimensions, setWindowDimensions] = useState(Dimensions.get('window'));
-  const {colors} = useTheme();
+  const {colors, dark} = useTheme();
 
   const firstButtonRef = usePageFocusManagement(navigation);
 
@@ -97,7 +97,8 @@ export const ButtonExamplePage: React.FunctionComponent<{route?: any; navigation
       <Example title="A colored Button." code={example2jsx}>
         <Button
           title="Colored Button"
-          color={colors.primary}
+          color={dark ? colors.primary : '#63ce6cff'}
+          
           accessibilityLabel={'colored button'}
           onPress={() => {}}
         />


### PR DESCRIPTION
## Description
- Adding fix for the grading issue

### Why
In light mode the button color contrast ratio with text should be 4.5 to 1

Resolves [#801]

## Screenshots
Dark Mode:
<img width="966" height="601" alt="image" src="https://github.com/user-attachments/assets/8d75097a-cf9a-437c-a558-ef36c1e37eeb" />

Light Mode:
<img width="997" height="621" alt="image" src="https://github.com/user-attachments/assets/8395b728-5436-4643-b597-ed8f1cd18445" />



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/807)