### PR TITLE
Fix redundant screen reader announcements for expander buttons

### DIFF
--- a/NewArch/src/App.tsx
+++ b/NewArch/src/App.tsx
@@ -240,7 +240,7 @@ const DrawerCollapsibleCategory = ({
         onHoverIn={() => setIsHovered(true)}
         onHoverOut={() => setIsHovered(false)}
         accessibilityRole="button"
-        accessibilityLabel={`${categoryLabel}, ${isExpanded ? 'expanded' : 'collapsed'}`}
+        accessibilityLabel={categoryLabel}
         accessibilityState={{expanded: isExpanded}}
         {...(positionInSet && setSize ? {accessibilityPosInSet: positionInSet, accessibilitySetSize: setSize} : {})}
         accessibilityActions={[

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -194,6 +194,7 @@ const DrawerCollapsibleCategory = ({
       accessible={true}
       accessibilityRole="button"
       accessibilityLabel={categoryLabel}
+      accessibilityState={{expanded: isExpanded}}
       onAccessibilityTap={() => setIsExpanded(!isExpanded)}>
       <Pressable
         style={localStyles.drawerListItem}


### PR DESCRIPTION
## Description

This PR fixes redundant screen reader announcements for the collapsible category buttons in the left navigation drawer.

### Why

When using Windows Narrator with the app, expanding/collapsing a category in the navigation drawer caused the expanded/collapsed state to be announced twice. For example: "Basic Input, collapsed, button, collapsed, 1 of 11" - the "collapsed" state is announced twice.

This happened because:
1. The `accessibilityLabel` prop contained the state text (e.g., "Basic Input, collapsed")
2. The `accessibilityState={{expanded: isExpanded}}` prop also communicated the state to the screen reader

### What

- **NewArch/src/App.tsx**: Removed the expanded/collapsed state from the `accessibilityLabel` prop, keeping only the category label. The `accessibilityState` prop already handles communicating the expanded state to screen readers.
- **src/App.tsx**: Added `accessibilityState={{expanded: isExpanded}}` to ensure the state is properly communicated (this file was missing the accessibility state prop).

## Screenshots

N/A - Accessibility fix, no visual changes

## Testing

1. Open the app with Windows Narrator enabled
2. Navigate to the left drawer navigation
3. Focus on a collapsible category button (e.g., "Basic Input")
4. Expand and collapse the category
5. Verify Narrator announces the state only once (e.g., "Basic Input, collapsed, button, 1 of 11")

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/813)