### PR TITLE
Fix misleading accessibility hint on FlatList items

### DIFF
--- a/NewArch/src/examples/FlatListExamplePage.tsx
+++ b/NewArch/src/examples/FlatListExamplePage.tsx
@@ -95,9 +95,8 @@ export const FlatListExamplePage: React.FunctionComponent<{navigation?: any}> = 
         borderColor: colors.border,
         borderRadius: 4,
       }}
-      accessibilityRole="button"
-      accessibilityLabel={`List item ${item.id}: ${item.title}`}
-      accessibilityHint="Tap to select this item"
+      accessibilityRole="text"
+      accessibilityLabel={`${item.title}`}
       onPress={() => {
         console.log(`Selected: ${item.title}`);
       }}


### PR DESCRIPTION
## Description

This PR fixes a misleading screen reader announcement on FlatList items.

### Why

In the "A FlatList with header and footer" section, Narrator announces "Tap to select this item" when navigating over each list item. However, tapping or activating the item does not perform any visible action - the items are not actually selectable despite the announcement implying interactivity.

This confuses screen reader users who attempt to interact with items that don't respond, leading to frustration and reduced trust in the interface.

### What

- **NewArch/src/examples/FlatListExamplePage.tsx**: 
  - Removed `accessibilityHint="Tap to select this item"` from the `renderAccessibleItem` function
  - Changed `accessibilityRole` from `"button"` to `"text"` since items are non-interactive
  - Simplified `accessibilityLabel` to just display the item title

## Screenshots

N/A - Accessibility fix, no visual changes

## Testing

1. Open the app with Windows Narrator enabled
2. Navigate to All Samples > FlatList
3. Navigate to the list items in "A FlatList with header and footer" section
4. Verify Narrator no longer says "Tap to select this item"
5. Verify items are announced simply as text (e.g., "Item 1") without implying they are interactive buttons

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/814)