### PR TITLE
Fix keyboard focus visibility after Settings in navigation

### DIFF
--- a/NewArch/src/App.tsx
+++ b/NewArch/src/App.tsx
@@ -355,6 +355,34 @@ function CustomDrawerContent({ navigation }: { navigation: any }) {
     }
   };
 
+  // Handler for Settings button - cycles focus back to hamburger on Tab
+  const handleSettingsKeyDown = (e: any) => {
+    if (e.nativeEvent.key === 'Tab' && !e.nativeEvent.shiftKey) {
+      // Prevent default Tab behavior and cycle focus to hamburger
+      e.preventDefault();
+      if (hamburgerRef.current) {
+        hamburgerRef.current.focus();
+      }
+    } else if (e.nativeEvent.key === 'ArrowDown' || e.nativeEvent.key === 'ArrowUp') {
+      // Allow default focus management for arrow keys
+      return;
+    }
+  };
+
+  // Handler for hamburger button - cycles focus to Settings on Shift+Tab
+  const handleHamburgerKeyDown = (e: any) => {
+    if (e.nativeEvent.key === 'Tab' && e.nativeEvent.shiftKey) {
+      // Prevent default Shift+Tab behavior and cycle focus to Settings
+      e.preventDefault();
+      if (settingsRef.current) {
+        settingsRef.current.focus();
+      }
+    } else if (e.nativeEvent.key === 'ArrowDown' || e.nativeEvent.key === 'ArrowUp') {
+      // Allow default focus management for arrow keys
+      return;
+    }
+  };
+
   // When drawer opens, focus the Home menu item
   useEffect(() => {
     if (isDrawerOpen && homeRef.current) {
@@ -390,7 +418,7 @@ function CustomDrawerContent({ navigation }: { navigation: any }) {
           }
         }}
         {...({
-          onKeyDown: handleKeyDown,
+          onKeyDown: handleHamburgerKeyDown,
           keyboardEvents: ['keyDown'],
           focusable: true,
         } as any)}>
@@ -440,7 +468,7 @@ function CustomDrawerContent({ navigation }: { navigation: any }) {
               icon="&#xE713;"
               navigation={navigation}
               currentRoute={currentRoute}
-              onKeyDown={handleKeyDown}
+              onKeyDown={handleSettingsKeyDown}
               keyboardEvents={['keyDown']}
               focusable={true}
             />


### PR DESCRIPTION
## Description

This PR fixes keyboard focus visibility issue when tabbing past the Settings button in the left navigation panel.

### Why

When the user pressed Tab on the 'Settings' button (the last item in the left navigation panel), keyboard focus moved to the next focusable element but the focus indicator was not visible anywhere on the screen. Users could not identify where the focus had gone.

Keyboard-only users lost track of navigation flow and were unable to continue interacting with the page. This created confusion, interrupted workflow, and prevented users with motor impairments from completing tasks.

### What

- **NewArch/src/App.tsx**: 
  - Added `handleSettingsKeyDown` handler that cycles focus back to the hamburger menu when Tab is pressed on Settings
  - Added `handleHamburgerKeyDown` handler that cycles focus to Settings when Shift+Tab is pressed on hamburger
  - This creates a focus trap within the drawer navigation so focus never disappears to an invisible element

## Screenshots



https://github.com/user-attachments/assets/e525e590-a7de-4a99-afec-cec7052a402c


## Testing

1. Open the app
2. Open the navigation drawer
3. Navigate to the Settings button (last item in the left navigation panel)
4. Press Tab
5. Verify focus moves to the hamburger menu (visible focus indicator)
6. Press Shift+Tab on hamburger
7. Verify focus moves to Settings (visible focus indicator)
8. Focus should always remain visible within the navigation panel

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/816)