### PR TITLE
Adding missing github issue link

### DIFF
--- a/NewArch/src/SettingsPage.tsx
+++ b/NewArch/src/SettingsPage.tsx
@@ -105,7 +105,7 @@ export const SettingsPage: React.FunctionComponent<{}> = () => {
         <SettingContainer heading="Found a bug? Want a new sample?">
           <Text style={styles.text}>
             If you have found a bug within the React Native Gallery app, please
-            file an issue on GitHub:
+            file an issue on GitHub: https://github.com/microsoft/react-native-gallery/issues
           </Text>
 
           <Text style={styles.text}>


### PR DESCRIPTION
## Description

The settings page has missing GitHub issue link

### Why

The users of the react-native-gallery app will not be able to raise a new issue if we don't provide the link

Resolves [https://github.com/microsoft/react-native-gallery/issues/770]

### What

The settings page has missing GitHub issue link
.
## Screenshots
Before
<img width="986" height="852" alt="770-before" src="https://github.com/user-attachments/assets/66f0008a-9b8d-4228-8a48-45f04332a5d3" />
After
<img width="1030" height="846" alt="770-after" src="https://github.com/user-attachments/assets/ca6ba5c5-0ca6-48e7-ae81-65a90251ad11" />


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/817)