### PR TITLE
Adding valid URL for button source code

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ steps:
   - task: CmdLine@2
     displayName: Lint and Type Checks
     inputs:
-      script: yarn tsc && yarn lint
+      script: yarn tsc | yarn lint
 
   - task: CmdLine@2
     displayName: Build project (Debug)

--- a/ci.yml
+++ b/ci.yml
@@ -74,7 +74,7 @@ steps:
   - task: CmdLine@2
     displayName: Lint and Type Checks
     inputs:
-      script: yarn tsc && yarn lint
+      script: yarn tsc | yarn lint
 
   - task: DownloadSecureFile@1
     name: signingCert


### PR DESCRIPTION
## Description

In Gallery app Button Source Code section leads to a URL, where the source code of button component is defined in react native windows. The link is broken

  ### Why

We need to fix the link so that users can see Button Component source code.

Resolves [https://github.com/microsoft/react-native-gallery/issues/775]

### What

Changed the URL to a valid one

## Screenshots

Before

https://github.com/user-attachments/assets/9dd9858e-98e0-4348-8acc-e3d36a158ab0


After

https://github.com/user-attachments/assets/df04dc08-3adb-4f8f-8505-12996ec52316


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/818)