### PR TITLE
Remove empty Date & time category from navigation

### DIFF
--- a/NewArch/src/RNGalleryList.ts
+++ b/NewArch/src/RNGalleryList.ts
@@ -48,7 +48,6 @@ import {VirtualizedListExamplePage} from './examples/VirtualizedListExamplePage'
 let RNGalleryCategories = [
   {label: 'Basic Input', icon: '\uE73A'},
   {label: 'Collections', icon: '\uE80A'},
-  {label: 'Date & time', icon: '\uEC92'},
   {label: 'Dialogs & flyouts', icon: '\uE8BD'},
   {label: 'Layout', icon: '\uE8A1'},
   {label: 'Media', icon: '\uE786'},


### PR DESCRIPTION
## Description
Remove empty Date & time category from navigation

### Why
No core support and hence deprecated.



Resolves
https://github.com/microsoft/react-native-gallery/issues/800

### What
Remove empty Date & time category from navigation



## Screenshots

https://github.com/user-attachments/assets/7753fc62-5b0d-4381-86ee-5344018cc2d1



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/822)