### PR TITLE
Fix screen reader announcement for indeterminate ProgressView

### DIFF
--- a/NewArch/src/examples/ProgressViewExamplePage.tsx
+++ b/NewArch/src/examples/ProgressViewExamplePage.tsx
@@ -35,9 +35,10 @@ export const ProgressViewExamplePage: React.FunctionComponent<{}> = () => {
       </Example>
       <Example title="An indeterminate ProgressView." code={example2jsx}>
         <ProgressView
-          accessibilityLabel="Indeterminate ProgressView"
-          isIndeterminate="true"
+              accessibilityLabel="Indeterminate progress bar"
+              isIndeterminate={true}
         />
+
       </Example>
       <Example
         title="A colored ProgressView with 70% progress."


### PR DESCRIPTION
This updates the accessibilityLabel for the indeterminate ProgressView so that screen readers announce the correct value.

Resolves #510

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/829)