### PR TITLE
[0.82] Updates the React Native Gallery (New Architecture) version from 2.0.9.0 to 2.1.0.0

### DIFF
--- a/NewArch/package.json
+++ b/NewArch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NewArch",
-  "version": "2.0.9.0",
+  "version": "2.1.0.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/NewArch/windows/NewArch.Package/Package.appxmanifest
+++ b/NewArch/windows/NewArch.Package/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="Microsoft.ReactNativeGallery-Experimental"
     Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
-    Version="2.0.9.0" />
+    Version="2.1.0.0" />
 
   <Properties>
     <DisplayName>React Native Gallery</DisplayName>


### PR DESCRIPTION
## Description
Updated version in NewArch/package.json
Updated version in NewArch/windows/NewArch.Package/Package.appxmanifest

### Why
Part of Release 0.82

Resolves [Add Relevant Issue Here]

### What
Updated version in NewArch/package.json
Updated version in NewArch/windows/NewArch.Package/Package.appxmanifest



## Screenshots

<img width="1605" height="1151" alt="image" src="https://github.com/user-attachments/assets/f87dc2b4-ec31-481b-95c1-6bb13b2bc635" />


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/835)