### PR TITLE
Removing Value prop in text input

### DIFF
--- a/NewArch/src/examples/TextInputExamplePage.tsx
+++ b/NewArch/src/examples/TextInputExamplePage.tsx
@@ -10,10 +10,10 @@ export const TextInputExamplePage: React.FunctionComponent<{navigation?: any}> =
   const firstTextInputExampleRef = usePageFocusManagement(navigation);
   const {colors} = useTheme();
 
-  const [text1, setText1] = React.useState('');
-  const [text2, setText2] = React.useState('');
-  const [text3, setText3] = React.useState('');
-  const [text4, setText4] = React.useState('');
+  const [_text1, setText1] = React.useState('');
+  const [_text2, setText2] = React.useState('');
+  const [_text3, setText3] = React.useState('');
+  const [_text4, setText4] = React.useState('');
 
   const onChangeText1 = (text: string) => {
     setText1(text);


### PR DESCRIPTION
## Description
Text Input is getting focused at the front of the text , when re-rendering.


### Why
Removed the value prop , because it is setting the text explicitly when re-rendering.  Its makes the focus to move front.


### What

value prop is removed, cause richedit will take care it when re-rendering.

## Screenshots

https://github.com/user-attachments/assets/9e82432e-2bd4-4c9e-85a7-bd45eddbbc01
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/841)