### PR TITLE
Removing status & info from navigation menu

### DIFF
--- a/NewArch/src/RNGalleryList.ts
+++ b/NewArch/src/RNGalleryList.ts
@@ -52,7 +52,7 @@ let RNGalleryCategories = [
   {label: 'Layout', icon: '\uE8A1'},
   {label: 'Media', icon: '\uE786'},
   {label: 'Scrolling', icon: '\uE8CB'},
-  {label: 'Status and Info', icon: '\uE8F2'},
+  // {label: 'Status and Info', icon: '\uE8F2'},
   {label: 'Text', icon: '\uE8D2'},
   {label: 'System', icon: '\uE7F8'},
   {label: 'Legacy', icon: '\uE96A'},


### PR DESCRIPTION
## Description

Removed status & info from navigation menu

### Why

Statues & Info didn't have anything

### What

Removed status & info from navigation menu

## Screenshots

<img width="979" height="1041" alt="status" src="https://github.com/user-attachments/assets/78f0a904-53f1-4a3e-96c6-0dd28ad0f4ba" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/849)