### PR TITLE
added color property in home page

### DIFF
--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -60,6 +60,7 @@ const createStyles = () =>
       fontSize: 40,
       fontWeight: '600', // SemiBold
       paddingLeft: 36,
+      color: 'black',
     },
   });
 


### PR DESCRIPTION
## Description

Added color property for HomePage as the title React Native Gallery is not visible properly

### Why

Added color property for HomePage as the title React Native Gallery is not visible properly. 
This change was added to make sure the title in Home Page is propely visible

Resolves [https://github.com/microsoft/react-native-windows/issues/15927]

### What

Added color property for HomePage as the title React Native Gallery is not visible properly. 
This change was added to make sure the title in Home Page is propely visible

## Screenshots

Before

<img width="502" height="512" alt="bb_before_dark" src="https://github.com/user-attachments/assets/38ff1045-ee2d-42f3-b3f9-24f482c6144f" />

After

Dark Mode
<img width="506" height="495" alt="bb_after_dark" src="https://github.com/user-attachments/assets/0bf70234-8a17-4e1c-a337-e6d25792992d" />

Light Mode
<img width="502" height="496" alt="bb_after_light" src="https://github.com/user-attachments/assets/5255958b-3a46-498c-ac2c-75bbe56db45c" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/886)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/895)