### PR TITLE
Fix keyboard focus on disabled Back button

### DIFF
--- a/__tests__/BackButton.test.tsx
+++ b/__tests__/BackButton.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @format
+ */
+
+import React from 'react';
+import {act, create} from 'react-test-renderer';
+import {BackButton} from '../src/components/BackButton';
+
+let mockCanGoBack = false;
+
+jest.mock('../src/Navigation', () => ({
+  useNavigation: () => ({navigate: jest.fn()}),
+}));
+jest.mock('../src/hooks/useNavigationHistory', () => ({
+  useNavigationHistory: () => ({
+    canGoBack: mockCanGoBack,
+    goBack: jest.fn(() => 'Home'),
+    pushRoute: jest.fn(),
+  }),
+}));
+
+describe('BackButton', () => {
+  beforeEach(() => {
+    mockCanGoBack = false;
+  });
+
+  test('is skipped by keyboard focus when navigation history is empty', async () => {
+    let tree;
+    await act(async () => {
+      tree = create(<BackButton />);
+    });
+
+    const button = tree.root.find(
+      node => node.props.accessibilityLabel === 'Back',
+    );
+    expect(button.props.disabled).toBe(true);
+    expect(button.props.focusable).toBe(false);
+  });
+
+  test('is keyboard focusable when navigation history is available', async () => {
+    mockCanGoBack = true;
+
+    let tree;
+    await act(async () => {
+      tree = create(<BackButton />);
+    });
+
+    const button = tree.root.find(
+      node => node.props.accessibilityLabel === 'Back',
+    );
+    expect(button.props.disabled).toBe(false);
+    expect(button.props.focusable).toBe(true);
+  });
+});

--- a/__tests__/__snapshots__/App.test.tsx.snap
+++ b/__tests__/__snapshots__/App.test.tsx.snap
@@ -177,7 +177,7 @@ exports[`Button Example Page 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onAccessibilityTap={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
@@ -1997,7 +1997,7 @@ exports[`Clipboard Example Page 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onAccessibilityTap={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
@@ -3364,7 +3364,7 @@ exports[`Image Example Page 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onAccessibilityTap={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
@@ -5720,7 +5720,7 @@ exports[`Pressable Example Page 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onAccessibilityTap={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
@@ -8539,7 +8539,7 @@ exports[`ScrollView Example Page 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onAccessibilityTap={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
@@ -10890,7 +10890,7 @@ exports[`Switch Example Page 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onAccessibilityTap={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
@@ -12240,7 +12240,7 @@ exports[`Text Example Page 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onAccessibilityTap={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
@@ -15583,7 +15583,7 @@ exports[`TextInput Example Page 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onAccessibilityTap={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
@@ -17494,7 +17494,7 @@ exports[`TouchableHighlight Example Page 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onAccessibilityTap={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
@@ -19721,7 +19721,7 @@ exports[`TouchableOpacity Example Page 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onAccessibilityTap={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
@@ -23363,7 +23363,7 @@ exports[`View Example Page 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onAccessibilityTap={[Function]}
         onBlur={[Function]}
         onClick={[Function]}
@@ -28787,7 +28787,7 @@ exports[`VirtualizedList Example Page 1`] = `
         }
         accessible={true}
         collapsable={false}
-        focusable={true}
+        focusable={false}
         onAccessibilityTap={[Function]}
         onBlur={[Function]}
         onClick={[Function]}

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -85,6 +85,7 @@ export function BackButton() {
       onPressOut={() => setIsPressed(false)}
       onHoverIn={() => setIsHovered(true)}
       onHoverOut={() => setIsHovered(false)}
+      focusable={canGoBack}
       disabled={!canGoBack}>
       {/* E72B = ChevronLeft / Back arrow in Segoe MDL2 Assets */}
       <Text style={[styles.icon, {color: iconColor}]}>{'\uE72B'}</Text>


### PR DESCRIPTION
## Summary
- Remove the Back button from the keyboard tab order when navigation history is unavailable.
- Restore keyboard focusability when the Back button can navigate.
- Add tests covering both navigation-history states.

This fixes bug #[63940832](https://dev.azure.com/microsoft/8d47e068-03c8-4cdc-aa9b-fc6929290322/_workitems/edit/63940832).

## Validation
- With no navigation history, Tab moves from the Navigation menu directly to the first visible page control.
- With navigation history, Tab moves from the Navigation menu to the Back button.
- Enter on the enabled Back button returns to the previous page.
- All 15 Jest tests pass.
- Lint passes with no errors.
- Windows Debug x64 build and deployment pass.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/920)