### PR TITLE
Fix FlatList initial focus order

### DIFF
--- a/__tests__/FlatListExamplePage.test.tsx
+++ b/__tests__/FlatListExamplePage.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * @format
+ */
+
+import React from 'react';
+import {FlatList} from 'react-native';
+import {
+  act,
+  create,
+  ReactTestInstance,
+  ReactTestRenderer,
+} from 'react-test-renderer';
+import {FlatListExamplePage} from '../src/examples/FlatListExamplePage';
+
+const mockPageFocusRef = {
+  current: null as any,
+};
+
+jest.mock('../src/hooks/usePageFocusManagement', () => ({
+  usePageFocusManagement: () => mockPageFocusRef,
+}));
+
+test('uses the first list item as the page focus target', async () => {
+  mockPageFocusRef.current = null;
+  let tree!: ReactTestRenderer;
+
+  await act(async () => {
+    tree = create(<FlatListExamplePage />);
+  });
+
+  const containsFocusTarget = (node: ReactTestInstance) =>
+    node.instance === mockPageFocusRef.current ||
+    node.findAll(child => child.instance === mockPageFocusRef.current).length >
+      0;
+
+  const firstItems = tree.root.findAll(
+    node => node.props.accessibilityLabel === 'Item 1',
+  );
+  const copyButtons = tree.root.findAll(
+    node => node.props.accessibilityLabel === 'Copy to clipboard',
+  );
+  const flatLists = tree.root.findAllByType(FlatList);
+
+  expect(firstItems.some(containsFocusTarget)).toBe(true);
+  expect(flatLists.map(containsFocusTarget)).toEqual([
+    true,
+    false,
+    false,
+    false,
+    false,
+  ]);
+  expect(copyButtons.some(containsFocusTarget)).toBe(false);
+});

--- a/src/examples/FlatListExamplePage.tsx
+++ b/src/examples/FlatListExamplePage.tsx
@@ -34,8 +34,10 @@ const Data = [
   }
 ];
 
+type FlatListItem = (typeof Data)[number];
+
 export const FlatListExamplePage: React.FunctionComponent<{navigation?: any}> = ({navigation}) => {
-  const firstFlatListRef = usePageFocusManagement(navigation);
+  const firstFlatListItemRef = usePageFocusManagement(navigation);
   const {colors} = useTheme();
 
   const example1jsx = `<FlatList
@@ -83,8 +85,9 @@ export const FlatListExamplePage: React.FunctionComponent<{navigation?: any}> = 
   numColumns={3}/>`;
 
   // Create a specialized render function for the fixed-height example to improve accessibility
-  const renderAccessibleItem = ({item}: {item: any}) => (
+  const renderItem = (item: FlatListItem, itemRef?: React.Ref<Pressable>) => (
     <Pressable
+      ref={itemRef}
       style={{
         width: 75,
         padding: 10,
@@ -107,6 +110,18 @@ export const FlatListExamplePage: React.FunctionComponent<{navigation?: any}> = 
     </Pressable>
   );
 
+  const renderAccessibleItem = ({item}: {item: FlatListItem}) =>
+    renderItem(item);
+
+  const renderFirstFlatListItem = ({
+    item,
+    index,
+  }: {
+    item: FlatListItem;
+    index: number;
+  }) =>
+    renderItem(item, index === 0 ? firstFlatListItemRef : undefined);
+
   return (
     <Page
       title="FlatList"
@@ -123,10 +138,10 @@ export const FlatListExamplePage: React.FunctionComponent<{navigation?: any}> = 
           url: 'https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Lists/FlatList.js',
         },
       ]}>
-      <Example ref={firstFlatListRef} title="A simple FlatList." code={example1jsx}>
+      <Example title="A simple FlatList." code={example1jsx}>
         <FlatList
           data={Data}
-          renderItem={renderAccessibleItem}
+          renderItem={renderFirstFlatListItem}
           keyExtractor={(item) => item.id}
           contentContainerStyle={{alignItems: 'center'}}
         />


### PR DESCRIPTION
## Summary
- Move the FlatList page's initial focus target from the Copy to clipboard button to Item 1 of the first FlatList.
- Preserve the natural keyboard order through Items 1–6, the source-code block, and the Copy to clipboard button.
- Add regression coverage verifying that only the first FlatList contains the page-focus target and that the Copy button does not receive it.

## Regression classification
This is **not a regression caused by the React Native or React Native Windows 0.85 changes**.

The incorrect focus wiring was introduced by React Native Gallery PR #879 on March 31, 2026, when the Gallery was using React Native 0.82.1 and React Native Windows 0.82.0.

## Validation
- Confirmed initial focus lands on Item 1 after opening the FlatList page.
- Confirmed the behavior after leaving and reopening the page.
- Confirmed forward and reverse keyboard traversal.
- Confirmed the Copy to clipboard button remains keyboard accessible.
- All 16 Jest tests and 13 snapshots pass.
- Lint passes with zero errors.
- Debug x64 Windows build succeeds with zero errors.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/922)