### PR TITLE
Restore navigation menu accessibility announcement

### DIFF
--- a/__tests__/ScreenWrapper.test.tsx
+++ b/__tests__/ScreenWrapper.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * @format
+ */
+
+import React from 'react';
+import {AccessibilityInfo, View} from 'react-native';
+import {act, create} from 'react-test-renderer';
+import {ScreenWrapper} from '../src/components/ScreenWrapper';
+
+test('announces when the navigation menu is expanded', () => {
+  const announceSpy = jest
+    .spyOn(AccessibilityInfo, 'announceForAccessibility')
+    .mockImplementation(() => {});
+
+  let tree;
+  act(() => {
+    tree = create(
+      <ScreenWrapper>
+        <View />
+      </ScreenWrapper>,
+    );
+  });
+
+  const navigationMenu = tree.root.findByProps({
+    accessibilityLabel: 'Navigation menu',
+  });
+
+  act(() => {
+    navigationMenu.props.onPress();
+  });
+
+  expect(announceSpy).toHaveBeenCalledWith('Navigation menu expanded');
+});

--- a/src/components/ScreenWrapper.tsx
+++ b/src/components/ScreenWrapper.tsx
@@ -6,6 +6,7 @@ import {
   TouchableHighlight,
   Text,
   PlatformColor,
+  AccessibilityInfo,
   Dimensions,
   Easing,
   useAnimatedValue,


### PR DESCRIPTION
## Summary
Gallery PR #921 removed the `AccessibilityInfo` import from `ScreenWrapper.tsx` while leaving two references to `AccessibilityInfo.announceForAccessibility`.

As a result, opening the navigation drawer throws:
`Property 'AccessibilityInfo' doesn't exist`

This change:
- Restores the missing `AccessibilityInfo` import.
- Adds regression coverage that invokes the navigation-menu handler and verifies the expansion announcement.
- Does not change navigation state, layout, accessibility properties, or event-handler behavior.

## Validation
- Focused `ScreenWrapper` regression test passed.
- Full test suite passed: 16/16 tests and 13/13 snapshots.
- Lint passed.
- Debug x64 Windows build succeeded with zero errors.
- Fresh app runtime validation passed through eight consecutive drawer open/close cycles.
- No LogBox, `AccessibilityInfo`, `ReferenceError`, or `TypeError` errors occurred.
- The app remained responsive throughout testing.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-gallery/pull/924)